### PR TITLE
Add parameter handling for !cr add !define command

### DIFF
--- a/aggregators/rules/cr.js
+++ b/aggregators/rules/cr.js
@@ -1,16 +1,96 @@
+var request = require("request");
+var console = require("console");
+
+const CR_ADDRESS = process.env.CR_ADDRESS; // http://media.wizards.com/2016/docs/MagicCompRules_20160930.txt or newer
+
 class CR{
     constructor(){
-        this.Location = "http://blogs.magicjudges.org/rules/cr/";
+		this.location = "http://blogs.magicjudges.org/rules/cr/";
+		request({url: CR_ADDRESS, encoding: "utf16le"}, (error, response, body) => {
+			 if (!error && response.statusCode == 200) {
+				 let {cr, glossary} = parseCR(body);
+				 this.cr = cr;
+				 this.glossary = glossary;
+				 console.log("CR Ready")
+			 } else {
+				 console.error(error);
+			 }
+		});
     }
     find (parameter,callback){
-        //todo
+        callback(this.cr.get(parameter.trim().replace(/\.$/, "").toLowerCase()));
     }
     getContent(parameter,callback) {
         if (parameter) {
-            this.find(parameter, callback());
+            this.find(parameter, callback);
         } else {
-            callback(this.Location);
+            callback(this.location);
         }
     }
+	getGlossaryEntry(parameter, callback) {
+		callback(this.glossary.get(parameter.trim().toLowerCase()));
+	}
 }
+
+
+function parseCR(crText) {
+	crText = crText.replace(/\r/g, "");
+
+	let rulesText = crText.substring(crText.search("\n\n100. General\n") + 2, crText.length);
+	let glossaryStartIndex = rulesText.search("\nGlossary\n") + 1;
+	let glossaryText = rulesText.substring(glossaryStartIndex, rulesText.search("\nCredits\n") + 1);
+	rulesText = rulesText.substring(0, glossaryStartIndex);
+
+	let glossaryEntries = parseGlossary(glossaryText);
+	let rulesEntries = parseRules(rulesText, glossaryEntries);
+
+	return {cr: rulesEntries, glossary: glossaryEntries};
+}
+
+function parseGlossary(glossaryText) {
+	let glossaryEntries = new Map();
+
+	for (let entry of glossaryText.split("\n\n")) {
+		if (!entry.trim()) {
+			continue;
+		}
+		let [term, definition] = entry.split("\n", 2);
+		if (!term || !definition) {
+			continue;
+		}
+		definition = `**${term}** ${highlightRules(definition)}`
+		for (let t of term.split(",")) {
+			glossaryEntries.set(t.trim().toLowerCase(), definition);
+		}
+	}
+	return glossaryEntries;
+}
+
+function parseRules(crText, glossaryEntries) {
+	const ruleNumberPrefixRe = /^\d{3}\.\w+\.?/;
+	let crEntries = new Map();
+
+	for (let entry of crText.split("\n\n")) {
+		if (!ruleNumberPrefixRe.test(entry)){
+			continue;
+		}
+		let number = entry.split(" ", 1)[0];
+		entry = entry.replace(ruleNumberPrefixRe, "__**$&**__");
+		let newEntry = [];
+		for (let word of entry.split(" ")) {
+			if (glossaryEntries.has(word)) {
+				newEntry.push( `__${word}__`);
+			} else {
+				newEntry.push(word);
+			}
+		}
+		crEntries.set(number.replace(/\.$/, ""), highlightRules(newEntry.join(" ")));	
+	}
+	return crEntries;
+}
+
+function highlightRules(text) {
+	return text.replace(/rule \d{3}\.\w*\.?/g, "**$&**");
+}
+
 module.exports = CR;

--- a/server.js
+++ b/server.js
@@ -1,17 +1,20 @@
 var Discord = require("discord.js");
 var bot = new Discord.Client();
-var mtrAggregator = new require("./aggregators/rules/mtr.js");
-var ipgAggregator = new require("./aggregators/rules/ipg.js");
-var crAggregator = new require("./aggregators/rules/cr.js");
-var jarAggregator = new require("./aggregators/rules/jar.js");
-var cardAggregator = new require("./aggregators/mtg_cards/cards.js");
 
-const mtr = "!mtr";
-const ipg = "!ipg";
-const cr = "!cr";
-const jar = "!jar";
-const card = "!card";
-const help = "!help";
+var mtrAggregator = new (require("./aggregators/rules/mtr.js"))();
+var ipgAggregator = new (require("./aggregators/rules/ipg.js"))();
+var crAggregator = new (require("./aggregators/rules/cr.js"))();
+var jarAggregator = new (require("./aggregators/rules/jar.js"))();
+var cardAggregator = new (require("./aggregators/mtg_cards/cards.js"))();
+
+var handlers = {
+	"!mtr": mtrAggregator.getContent,
+	"!ipg": ipgAggregator.getContent,
+	"!cr": crAggregator.getContent,
+	"!define": crAggregator.getGlossaryEntry,
+	"!jar": jarAggregator.getContent,
+	"!card": cardAggregator.getContent,
+}
 
 /**
  * @param msg.channel.sendMessage
@@ -21,26 +24,11 @@ bot.on("message", msg => {
 	const query = msg.content.split(" ");
 	const command = query[0].toLowerCase();
 	const parameter = query.length > 1 ? query.slice(1).join(" ") : "";
-	switch(command){
-		case mtr:
-			new mtrAggregator().getContent(parameter,respondToMsg);
-			break;
-        case ipg:
-            new ipgAggregator().getContent(parameter,respondToMsg);
-            break;
-        case cr:
-            new crAggregator().getContent(parameter,respondToMsg);
-            break;
-        case jar:
-            new jarAggregator().getContent(parameter,respondToMsg);
-            break;
-		case card:
-		    new cardAggregator().getContent(parameter,respondToMsg);
-			break;
-        case help:
-            //todo
-            break;
+	let handler = handlers[command];
+	if (handler) {
+		handler(parameter, respondToMsg);
 	}
+
 	function respondToMsg(response) {
         if(response){
             msg.channel.sendMessage(response);


### PR DESCRIPTION
!cr [RuleNumber] can now be used to query a specific CR entry.

!define [word] can be used to look up that word in the CR glossary.

The CR entries and glossary are parsed from the official CR txt release.

The url to retrieve the official txt release of the CR has to be
configured as process.env.CR_ADDRESS.

Slight rework of server.js:

Instantiate each aggregator object only once and not on every command. Use
an object as a lookup table instead of the switch case.
