### PR TITLE
Upload cards as attachment and cleanup cards.js

### DIFF
--- a/aggregators/mtg_cards/cards.js
+++ b/aggregators/mtg_cards/cards.js
@@ -1,87 +1,79 @@
 const request = require("request");
+const _ = require("lodash");
+
 class MtgCardLoader {
     constructor() {
         this.cardApi = "https://api.magicthegathering.io/v1/cards?name=";
     }
-
-    find(cardName, callback) {
-        request({
-                url: this.cardApi + cardName,
-                json: true
-            },
-            /**
-             * @param response
-             * @param error
-             * @param body
-             * @param body.cards array of cards
-             * @param body.cards.loyalty string
-             * @param body.cards.power string
-             * @param body.cards.imageUrl string
-             * @param body.cards.toughness string
-             * @param body.cards.printings array of printings
-             **/
-            (error, response, body) => {
-                if (!error && response.statusCode === 200 && body.cards && body.cards.length) {
-                    const cardMap = new Map();
-                    body.cards.forEach(function(card){
-                        if(cardMap.has(card.name)){
-                            if(!cardMap.get(card.name).imageUrl && card.imageUrl){
-                                cardMap.set(card.name,card);
-                            }
-                        }else{
-                            cardMap.set(card.name,card);
-                        }
-                    });
-                    const cards =  Array.from(cardMap).map(function(element){
-                        return element[1];
-                    });
-                    let card = cards.find(function(card){
-                        return card.name.toLowerCase() === cardName;
-                    });
-                    if(!card){
-                        card = cards.find(function (card) {
-                           return card.name.toLowerCase().startsWith(cardName);
-                        })
-                    }
-                    if(!card){
-                        card = cards[0];
-                    }
-                    const cardInfo = ["**" + card.name + "**"];
-                    if (card.type) {
-                        cardInfo.push(card.type);
-                    }
-                    if (card.text) {
-                        cardInfo.push(card.text.replace(/\*/g, '\\*'));
-                    }
-                    if (card.loyalty) {
-                        cardInfo.push(card.loyalty);
-                    }
-                    if (card.power) {
-                        cardInfo.push(card.power.replace(/\*/g, '\\*') + "/" + card.toughness.replace(/\*/g, '\\*'));
-                    }
-                    if (card.printings) {
-                        cardInfo.push(card.printings.join(", "));
-                    }
-                    cardInfo.push("http://magiccards.info/query?q=!" + encodeURIComponent(card.name));
-                    if (card.imageUrl) {
-                        cardInfo.push(card.imageUrl);
-                    }
-                    callback(cardInfo.join("\n"));
-                    if(cards.length>1){
-                        const cardNames = [];
-                        cards.forEach(function(element){
-                            if(!(element.name===card.name)){
-                                cardNames.push((element.name));
-                            }
-                        });
-                        callback("Other matching cards are: " + cardNames.join(", "))
-                    }
-                }
-            });
+    cardToString(card) {
+        const manaCost = card.manaCost ? " " + card.manaCost : "";
+        const cardInfo = ["**" + card.name + "**" + manaCost];
+        if (card.type) {
+            cardInfo.push(card.type);
+        }
+        if (card.text) {
+            cardInfo.push(card.text.replace(/\*/g, '\\*'));
+        }
+        if (card.loyalty) {
+            cardInfo.push(card.loyalty);
+        }
+        if (card.power) {
+            cardInfo.push(card.power.replace(/\*/g, '\\*') + "/" + card.toughness.replace(/\*/g, '\\*'));
+        }
+        if (card.printings) {
+            cardInfo.push(card.printings.join(", "));
+        }
+        cardInfo.push("http://magiccards.info/query?q=!" + encodeURIComponent(card.name));
+        return cardInfo.join("\n");
     }
+    findCard(cardName, cards) {
+        // create an array containing each card exactly once, preferring cards with image
+        const [cardsWithImage, cardsWithoutImage] = _.partition(cards, "imageUrl");
+        const differentCardsWithoutImage = _.differenceBy(cardsWithoutImage, cardsWithImage, "name");
+        const uniqCards = _.uniqBy(_.concat(cardsWithImage, differentCardsWithoutImage), "name");
 
+        // Look for an exact match by name
+        let card = uniqCards.find(c => c.name.toLowerCase() === cardName);
+        if (!card){
+            // Use a hit which shares the longest common prefix with the search term
+            card = _.maxBy(uniqCards, c => longestCommonPrefix(cardName, c.name.toLowerCase()));
+        }
+        return card;
+    }
     getContent(command , parameter, callback) {
-        this.find(parameter.toLowerCase(), callback);
+        const cardName = parameter.toLowerCase();
+        request({
+            url: this.cardApi + cardName,
+            json: true
+        },
+        (error, response, body) => {
+            if (!error && response.statusCode === 200 && body.cards && body.cards.length) {
+                const card = this.findCard(cardName, body.cards);
+                let response = this.cardToString(card);
+                let otherCardNames = body.cards.map(c => c.name).filter(n => n !== card.name);
+                if (otherCardNames.length) {
+                    otherCardNames.sort();
+                    otherCardNames = _.sortedUniq(otherCardNames);
+                    response += "\n\nOther matching cards: " + otherCardNames.join(", ");
+                }
+                callback(response, card.imageUrl, _.snakeCase(_.deburr(card.name)) + ".jpg");
+            }
+        });
     }
 }
+
+function longestCommonPrefix(...strings) {
+    if (strings.length === 0) {
+        return "";
+    }
+    for (let i = 0; i < strings[0].length; i++) {
+        for (let j = 1; j< strings.length; j++) {
+            if (strings[0][i] !== strings[j][i]) {
+                return strings[0].substring(0, i);
+            }
+        }
+    }
+    return strings[0];
+}
+
 module.exports = MtgCardLoader;

--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "description": "discord bot for judges",
   "main": "server.js",
   "engines": {
-	"node": "6.9.1"
+    "node": "6.9.1"
   },
   "scripts": {
-	"start": "node server.js",
+    "start": "node server.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
@@ -20,8 +20,9 @@
     "url": "https://github.com/bra1n/judgebot/issues"
   },
   "dependencies": {
+    "cheerio": "0.22.0",
     "discord.js": "^9.3.1",
-    "request": "^2.76.0",
-    "cheerio": "0.22.0"
+    "lodash": "^4.16.6",
+    "request": "^2.76.0"
   }
 }

--- a/server.js
+++ b/server.js
@@ -29,8 +29,10 @@ bot.on("message", msg => {
     if (handler) {
         handler.getContent(command, parameter, respondToMsg);
     }
-    function respondToMsg(response) {
-        if (response) {
+    function respondToMsg(response, attachment, filename) {
+        if (attachment) {
+            msg.channel.sendFile(attachment, filename, response);
+        } else if (response) {
             msg.channel.sendMessage(response);
         }
     }


### PR DESCRIPTION
Fixes #4 .

Not quite sure where to put `longestCommonPrefix`. Definitely doesn't belong on the class, feels like it should be in it's own module, but I'm not sure if we want relative paths all over the place (such as `require("../../helpers/stringhelper")`. An alternative would be using common-prefix from npm.

I have replaced the use of a map to find cards with card images with a slightly different approach using lodash, personally I find it more readable, if you think differently feel free to let me know.

I have tested this by running a selfbot and there is a noticable delay on answer times due to the image upload. I'm not sure if the added cleanliness is actually worth the delay, compared to just adding the cardImage URL to the message. 