### PR TITLE
Handle rejected promises correctly

### DIFF
--- a/modules/help.js
+++ b/modules/help.js
@@ -6,7 +6,7 @@ class Help {
             '!ipg': 'Show an entry from the Infraction Procedure Guide, *Example: !ipg 4.2, !ipg grv*',
             '!cr': 'Show an entry from the Comprehensive Rulebook, *Example: !cr 100.6b*',
             '!define': 'Show a definition from the Comprehensive Rulebook, *Example: !define phasing*'
-        }
+        };
     }
 
     getCommands() {
@@ -21,7 +21,7 @@ class Help {
         response += "\nThis judgebot is provided free of charge and can be added to your channel, too!\n";
         response += ":link: https://bots.discord.pw/bots/240537940378386442\n";
         response += ":link: https://github.com/bra1n/judgebot\n";
-        msg.author.sendMessage(response);
+        return msg.author.sendMessage(response);
     }
 }
 module.exports = Help;

--- a/modules/rules/cr.js
+++ b/modules/rules/cr.js
@@ -1,4 +1,3 @@
-const console = require("console");
 const request = require("request");
 const log = require("log4js").getLogger('cr');
 
@@ -84,12 +83,11 @@ class CR {
     handleMessage(command, parameter, msg) {
         if (command === "cr") {
             if (parameter && this.cr) {
-                msg.channel.sendMessage(this.cr[parameter.trim().replace(/\.$/, "").toLowerCase()]);
-            } else {
-                msg.channel.sendMessage('**Comprehensive Rules**: <' + this.location + '>');
+                return msg.channel.sendMessage(this.cr[parameter.trim().replace(/\.$/, "").toLowerCase()]);
             }
+            return msg.channel.sendMessage('**Comprehensive Rules**: <' + this.location + '>');
         } else if (command === "define" && parameter && this.glossary) {
-            msg.channel.sendMessage(this.glossary[parameter.trim().toLowerCase()]);
+            return msg.channel.sendMessage(this.glossary[parameter.trim().toLowerCase()]);
         }
     }
 }

--- a/modules/rules/jar.js
+++ b/modules/rules/jar.js
@@ -14,11 +14,9 @@ class JAR {
 
     handleMessage(command, parameter, msg) {
         if (parameter) {
-            msg.channel.sendMessage(this.find(parameter));
-        } else {
-            msg.channel.sendMessage('**Judging at Regular**: <' + this.Location + '>');
+            return msg.channel.sendMessage(this.find(parameter));
         }
-
+        return msg.channel.sendMessage('**Judging at Regular**: <' + this.Location + '>');
     }
 }
 module.exports = JAR;

--- a/modules/rules/mtr.js
+++ b/modules/rules/mtr.js
@@ -14,10 +14,9 @@ class MTR {
 
     handleMessage(command, parameter, msg) {
         if (parameter) {
-            msg.channel.sendMessage(this.find(parameter));
-        } else {
-            msg.channel.sendMessage('**Magic Tournament Rules**: <' + this.Location + '>');
+            return msg.channel.sendMessage(this.find(parameter));
         }
+        return msg.channel.sendMessage('**Magic Tournament Rules**: <' + this.Location + '>');
     }
 }
 module.exports = MTR;

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "discord.js": "^10.0.1",
     "lodash": "^4.16.6",
     "log4js": "^1.0.0",
-    "request": "^2.76.0"
+    "request": "^2.76.0",
+    "request-promise-native": "^1.0.3"
   }
 }

--- a/server.js
+++ b/server.js
@@ -54,7 +54,9 @@ bot.on("message", msg => {
     ];
     log.info(logMessage.join(' '));
     userMessageTimes[msg.author.id] = new Date().getTime();
-    handlers[command].handleMessage(command, parameter, msg);
+    const ret = handlers[command].handleMessage(command, parameter, msg);
+    // if ret is undefined or not a thenable this just returns a resolved promise and the callback won't be called
+    Promise.resolve(ret).catch(e => log.error('An error occured while handling', msg.content.green, ":\n", e));
 });
 
 /* Bot event listeners */


### PR DESCRIPTION
Fixes #24

Various discord.js methods return promises, return these from various
modules and write a log entry on rejection.

Switch to request-promise-native to make returning promises from the
modules using request easier.

In cards handle downloading the gatherer image manually instead of relying
on discords fileresolver, this allows us to differentiate an image
download error from an error that occurs while sending the discord
message, which enables us to fall back on sending a message without an
image.