### PR TITLE
Updated CR and fixed parser

### DIFF
--- a/modules/rules/cr.js
+++ b/modules/rules/cr.js
@@ -1,15 +1,18 @@
 const request = require("request");
+const iconv = require("iconv-lite");
 const log = require("log4js").getLogger('cr');
 
 // Using the current CR as the default, not sure if they actually stick around once new ones are published
-const CR_ADDRESS = process.env.CR_ADDRESS || "http://media.wizards.com/2016/docs/MagicCompRules_20160930.txt";
+const CR_ADDRESS = process.env.CR_ADDRESS || "https://sites.google.com/site/mtgfamiliar/rules/MagicCompRules.txt";
 
 class CR {
     constructor() {
         this.location = "http://blogs.magicjudges.org/rules/cr/";
         this.commands = ["define", "cr"];
+        this.glossary = {};
+        this.cr = {};
 
-        request({url: CR_ADDRESS, encoding: "utf16le"}, (error, response, body) => {
+        request({url: CR_ADDRESS}, (error, response, body) => {
             if (!error && response.statusCode === 200) {
                 this.initCR(body);
             } else {
@@ -25,8 +28,8 @@ class CR {
     initCR(crText) {
         crText = crText.replace(/\r/g, "");
         let rulesText = crText.substring(crText.search("\n\n100. General\n") + 2, crText.length);
-        const glossaryStartIndex = rulesText.search("\nGlossary\n") + 1;
-        const glossaryText = rulesText.substring(glossaryStartIndex, rulesText.search("\nCredits\n") + 1);
+        const glossaryStartIndex = rulesText.search("\nGLOSSARY_VERYLONGSTRINGOFLETTERSUNLIKELYTOBEFOUNDINTHEACTUALRULES\n") + 1;
+        const glossaryText = rulesText.substring(glossaryStartIndex, rulesText.search("\nEOF_VERYLONGSTRINGOFLETTERSUNLIKELYTOBEFOUNDINTHEACTUALRULES\n") + 1);
         rulesText = rulesText.substring(0, glossaryStartIndex);
 
         this.glossary = this.parseGlossary(glossaryText);
@@ -81,13 +84,14 @@ class CR {
     }
 
     handleMessage(command, parameter, msg) {
+        parameter = parameter.trim().replace(/\.$/, "").toLowerCase();
         if (command === "cr") {
-            if (parameter && this.cr) {
-                return msg.channel.sendMessage(this.cr[parameter.trim().replace(/\.$/, "").toLowerCase()]);
+            if (parameter && this.cr[parameter]) {
+                return msg.channel.sendMessage(this.cr[parameter]);
             }
             return msg.channel.sendMessage('**Comprehensive Rules**: <' + this.location + '>');
-        } else if (command === "define" && parameter && this.glossary) {
-            return msg.channel.sendMessage(this.glossary[parameter.trim().toLowerCase()]);
+        } else if (command === "define" && parameter && this.glossary[parameter]) {
+            return msg.channel.sendMessage(this.glossary[parameter]);
         }
     }
 }

--- a/modules/rules/cr.js
+++ b/modules/rules/cr.js
@@ -1,5 +1,4 @@
 const request = require("request");
-const iconv = require("iconv-lite");
 const log = require("log4js").getLogger('cr');
 
 // Using the current CR as the default, not sure if they actually stick around once new ones are published


### PR DESCRIPTION
New CR URL had a funky encoding, so I switched to the MTGFamiliar CR docs, which are also automatically updated, thus making frequent URL changes unnecessary.