### PR TITLE
Improved rendering and command parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ node server.js
 
 ## Supported commands
 
+Any supported command can be entered at any place in your message and should end with a second `!` or the end of the message.
+For example: `I'm looking for !card tarmogoyf! and !card noble hierarch` would show the cards Tarmogoyf and Noble Hierarch.
+
 - **!card \<partial cardname\>**: searches for an (English) card by name and outputs the card together with an image, if available, supports the full [Scryfall syntax](https://scryfall.com/docs/reference), *Example: !card Tarmogoyf*
 - **!price \<partial cardname\>**: searches for an (English) card by name and outputs the card together with prices in USD, EUR and TIX, *Example: !price Tarmogoyf*
 - **!legal \<partial cardname\>**: searches for an (English) card by name and outputs the card together with a list of formats where it is legal, *Example: !legal Tarmogoyf*

--- a/README.md
+++ b/README.md
@@ -19,7 +19,10 @@ node server.js
 
 ## Supported commands
 
-- **!card \<partial cardname\>**: searches for an (English) card by name and outputs the card together with an image, if available, *Example: !card Tarmogoyf*
+- **!card \<partial cardname\>**: searches for an (English) card by name and outputs the card together with an image, if available, supports the full [Scryfall syntax](https://scryfall.com/docs/reference), *Example: !card Tarmogoyf*
+- **!price \<partial cardname\>**: searches for an (English) card by name and outputs the card together with prices in USD, EUR and TIX, *Example: !price Tarmogoyf*
+- **!legal \<partial cardname\>**: searches for an (English) card by name and outputs the card together with a list of formats where it is legal, *Example: !legal Tarmogoyf*
+- **!ruling \<partial cardname\>**: searches for an (English) card by name and outputs the Gatherer rulings for that card, *Example: !ruling Tarmogoyf*
 - **!cr \<paragraph number\>**: shows the chosen paragraph from the [Comprehensive Rules](https://rules.wizards.com/rulebook.aspx?game=Magic&category=Game+Rules), *Example: !cr 100.6b*
 - **!define \<keyword\>**: shows the chosen keyword definition from the [Comprehensive Rules](https://rules.wizards.com/rulebook.aspx?game=Magic&category=Game+Rules), *Example: !define banding*
 - **!ipg \<paragraph number\>**: shows the chosen (sub-)section from the [Infraction Procedure Guide](http://blogs.magicjudges.org/rules/ipg/), *Example: !ipg 2.1, !ipg hce philosophy*

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Clone the Git repository and run the following commands:
 npm install
 export DISCORD_TOKEN="<your Discord bot token>"
 export CR_ADDRESS="http://media.wizards.com/2016/docs/MagicCompRules_20160930.txt"
-export IPG_ADDRESS=https://sites.google.com/site/mtgfamiliar/rules/InfractionProcedureGuide-light.html"
+export IPG_ADDRESS="https://sites.google.com/site/mtgfamiliar/rules/InfractionProcedureGuide-light.html"
 export MTR_ADDRESS="https://sites.google.com/site/mtgfamiliar/rules/MagicTournamentRules-light.html"
 node server.js
 ```

--- a/modules/card.js
+++ b/modules/card.js
@@ -257,7 +257,7 @@ class MtgCardLoader {
             requestPromise.then(response => {
                 if (response.data) {
                     // if cache is too big, remove the oldest entry
-                    if (this.cardCacheDict.length > this.cardCacheLimit) {
+                    if (this.cardCacheDict.length >= this.cardCacheLimit) {
                         delete this.cardCache[this.cardCacheDict.shift()];
                     }
                     // cache results

--- a/modules/help.js
+++ b/modules/help.js
@@ -2,7 +2,10 @@ class Help {
     constructor() {
         this.commands = ["help"];
         this.commandList = {
-            '!card': 'Search for an English Magic card by (partial) name, *Example: !card iona*',
+            '!card': 'Search for an English Magic card by (partial) name, supports full Scryfall syntax, *Example: !card iona*',
+            '!price': 'Show the price in USD, EUR and TIX for a card, *Example: !price iona*',
+            '!legal': 'Show the format legality for a card, *Example: !legal iona*',
+            '!ruling': 'Show the Gatherer rulings for a card, *Example: !ruling iona*',
             '!ipg': 'Show an entry from the Infraction Procedure Guide, *Example: !ipg 4.2, !ipg grv philosophy*',
             '!mtr': 'Show an entry from Magic: The Gathering Tournament Rules, *Example: !mtr 2, !mtr 4.2*',
             '!cr': 'Show an entry from the Comprehensive Rulebook, *Example: !cr 100.6b*',

--- a/modules/rules/cr.js
+++ b/modules/rules/cr.js
@@ -1,15 +1,19 @@
+const _ = require('lodash');
 const request = require("request");
 const log = require("log4js").getLogger('cr');
+const Discord = require('discord.js');
 
 // Using the current CR as the default, not sure if they actually stick around once new ones are published
 const CR_ADDRESS = process.env.CR_ADDRESS || "https://sites.google.com/site/mtgfamiliar/rules/MagicCompRules.txt";
 
 class CR {
     constructor() {
-        this.location = "http://blogs.magicjudges.org/rules/cr/";
-        this.commands = ["define", "cr"];
+        this.location = "http://blogs.magicjudges.org/rules/cr";
+        this.commands = ["define", "cr", "rule"];
         this.glossary = {};
-        this.cr = {};
+        this.thumbnail = 'https://assets.magicjudges.org/judge-banner/images/magic-judge.png';
+        this.crData = {};
+        this.maxLength = 2040;
 
         request({url: CR_ADDRESS}, (error, response, body) => {
             if (!error && response.statusCode === 200) {
@@ -26,13 +30,14 @@ class CR {
 
     initCR(crText) {
         crText = crText.replace(/\r/g, "");
-        let rulesText = crText.substring(crText.search("\n\n100. General\n") + 2, crText.length);
+        let rulesText = crText.substring(crText.search("\nRULES_VERYLONGSTRINGOFLETTERSUNLIKELYTOBEFOUNDINTHEACTUALRULES\n") + 1, crText.length);
         const glossaryStartIndex = rulesText.search("\nGLOSSARY_VERYLONGSTRINGOFLETTERSUNLIKELYTOBEFOUNDINTHEACTUALRULES\n") + 1;
         const glossaryText = rulesText.substring(glossaryStartIndex, rulesText.search("\nEOF_VERYLONGSTRINGOFLETTERSUNLIKELYTOBEFOUNDINTHEACTUALRULES\n") + 1);
         rulesText = rulesText.substring(0, glossaryStartIndex);
 
         this.glossary = this.parseGlossary(glossaryText);
-        this.cr = this.parseRules(rulesText, this.glossary);
+        this.crData = this.parseRules(rulesText, this.glossary);
+        this.crData.description = crText.split('\n')[0];
         log.info("CR Ready");
     }
 
@@ -47,7 +52,7 @@ class CR {
             if (!term || !definition) {
                 continue;
             }
-            definition = `**${term}** ${this.highlightRules(definition)}`;
+            definition = `**${term}**\n${this.highlightRules(definition)}`;
             for (const t of term.split(",")) {
                 glossaryEntries[t.trim().toLowerCase()] = definition;
             }
@@ -56,15 +61,15 @@ class CR {
     }
 
     parseRules(crText, glossaryEntries) {
-        const ruleNumberPrefixRe = /^\d{3}\.\w+\.?/;
+        const ruleNumberPrefixRe = /^(\d{3}\.\w+)\.?/;
         const crEntries = {};
 
         for (let entry of crText.split("\n\n")) {
             if (!ruleNumberPrefixRe.test(entry)) {
                 continue;
             }
-            const number = entry.split(" ", 1)[0];
-            entry = entry.replace(ruleNumberPrefixRe, "__**$&**__");
+            const number = entry.split(" ", 1)[0].replace(/\.$/, "");
+            entry = entry.replace(ruleNumberPrefixRe, "__**$1**__");
             const newEntry = [];
             for (const word of entry.split(" ")) {
                 if (glossaryEntries[word]) {
@@ -73,24 +78,67 @@ class CR {
                     newEntry.push(word);
                 }
             }
-            crEntries[number.replace(/\.$/, "")] = this.highlightRules(newEntry.join(" "));
+            entry = this.highlightRules(newEntry.join(" "));
+
+            crEntries[number] = '';
+            entry.split('\n').forEach(line => {
+                if (line.match(/^Example: /i)) {
+                    if (!crEntries[number+' ex']) crEntries[number+' ex'] = '';
+                    crEntries[number+' ex'] += line.replace(/^Example: /i, '**Example:** ') + '\n\n';
+                } else {
+                    crEntries[number] += line + '\n';
+                }
+            })
         }
         return crEntries;
     }
 
     highlightRules(text) {
-        return text.replace(/rule \d{3}\.\w*\.?/g, "**$&**");
+        return text.replace(/rule \d{3}\.\w*\.?/ig, "**$&**");
+    }
+
+    appendSubrules(parameter) {
+        let description = this.crData[parameter];
+        if (description && this.crData[parameter + 'a']) {
+            let x = 97; // 'a'
+            while(this.crData[parameter + String.fromCharCode(x)]) {
+                description += '\n\n' + this.crData[parameter + String.fromCharCode(x)];
+                x++;
+            }
+        }
+        return description;
     }
 
     handleMessage(command, parameter, msg) {
         parameter = parameter.trim().replace(/\.$/, "").toLowerCase();
-        if (command === "cr") {
-            if (parameter && this.cr[parameter]) {
-                return msg.channel.sendMessage(this.cr[parameter]);
+        if (command === "cr" || command === "rule") {
+            const embed = new Discord.RichEmbed({
+                title: 'Comprehensive Rules',
+                description: 'Effective '+this.crData.description,
+                thumbnail: {url: this.thumbnail},
+                url: this.location + '/'
+            });
+            if (parameter && this.crData[parameter]) {
+                embed.setTitle('CR - Rule '+parameter.replace(/ ex$/,' Examples'));
+                embed.setDescription(_.truncate(this.appendSubrules(parameter), {length: this.maxLength, separator: '\n'}));
+                embed.setURL(this.location + parameter.substr(0,3) + '/');
+                if (this.crData[parameter + ' ex']) {
+                    embed.setFooter('Use "!cr '+parameter+' ex" to see examples.');
+                }
             }
-            return msg.channel.sendMessage('**Comprehensive Rules**: <' + this.location + '>');
+            return msg.channel.send('', {embed});
         } else if (command === "define" && parameter && this.glossary[parameter]) {
-            return msg.channel.sendMessage(this.glossary[parameter]);
+            const embed = new Discord.RichEmbed({
+                title: 'CR - Glossary for "'+parameter+'"',
+                description: this.glossary[parameter],
+                thumbnail: {url: this.thumbnail},
+                url: this.location + '/cr-glossary/'
+            });
+            const rule = this.glossary[parameter].match(/rule (\d+\.\w+)/i);
+            if (rule && this.crData[rule[1]]) {
+                embed.addField('CR - Rule '+rule[1], _.truncate(this.appendSubrules(rule[1]), {length: 1020, separator: '\n'}));
+            }
+            return msg.channel.send('', {embed});
         }
     }
 }

--- a/modules/rules/cr.js
+++ b/modules/rules/cr.js
@@ -100,10 +100,9 @@ class CR {
     appendSubrules(parameter) {
         let description = this.crData[parameter];
         if (description && this.crData[parameter + 'a']) {
-            let x = 97; // 'a'
-            while(this.crData[parameter + String.fromCharCode(x)]) {
-                description += '\n\n' + this.crData[parameter + String.fromCharCode(x)];
-                x++;
+            // keep looking for subrules, starting with "123a" and going until "123z" or we don't find another subrule
+            for(let x = 'a'.charCodeAt(0); this.crData[parameter + String.fromCharCode(x)]; x++) {
+                description += '\n' + this.crData[parameter + String.fromCharCode(x)];
             }
         }
         return description;

--- a/modules/rules/ipg.js
+++ b/modules/rules/ipg.js
@@ -275,7 +275,7 @@ class IPG {
     }
 
     getChapters() {
-        return _
+        return Object
             .values(this.ipgData)
             .filter(c => c.title.match(/^\d+\s/))
             .map(c => '• '+c.title.replace(/^(\d+)\s/,'$1. '));

--- a/modules/rules/mtr.js
+++ b/modules/rules/mtr.js
@@ -14,6 +14,7 @@ class MTR {
         this.commands = ['mtr'];
         this.thumbnail = 'https://assets.magicjudges.org/judge-banner/images/magic-judge.png';
         this.mtrData = {
+            description: '',
             chapters: {appendices: {key: 'appendices', title: 'Appendices', sections: []}},
             sections: {}
         };
@@ -42,6 +43,9 @@ class MTR {
     }
 
     cleanup($) {
+        // get description from body
+        this.mtrData.description = $('body').get(0).childNodes[4].data.trim();
+
         // wrap standalone text nodes in p tags
         const nodes = $('body').contents();
         for (let i = 0; i < nodes.length; i++) {
@@ -183,7 +187,12 @@ class MTR {
             const embed = this.find(parameter.trim());
             return msg.channel.send('', {embed});
         }
-        return msg.channel.send('**Magic Tournament Rules**: <' + this.location + '>');
+        return msg.channel.send('', {embed: new Discord.RichEmbed({
+            title: 'Magic: The Gathering Tournament Rules',
+            description: this.mtrData.description,
+            thumbnail: {url: this.thumbnail},
+            url: this.location
+        })});
     }
 }
 

--- a/modules/rules/mtr.js
+++ b/modules/rules/mtr.js
@@ -1,7 +1,6 @@
 const _ = require('lodash');
 const cheerio = require('cheerio');
 const rp = require('request-promise-native');
-const Table = require('tty-table');
 const log = require('log4js').getLogger('mtr');
 const Discord = require('discord.js');
 

--- a/modules/rules/mtr.js
+++ b/modules/rules/mtr.js
@@ -166,7 +166,7 @@ class MTR {
             return new Discord.RichEmbed({
                 title: 'MTR - Error',
                 description: 'This section does not exist. Try asking for a chapter to get a list of available sections for that chapter.',
-                color: 0xff0000,
+                color: 0xff0000
             });
         }
 
@@ -178,7 +178,7 @@ class MTR {
         return new Discord.RichEmbed({
             title: 'MTR - Error',
             description: 'This chapter does not exist.',
-            color: 0xff0000,
+            color: 0xff0000
         }).addField('Available Chapters', availableChapters);
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "judgebot",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "discord bot for judges",
   "main": "server.js",
   "engines": {
@@ -22,7 +22,7 @@
   "dependencies": {
     "cheerio": "0.22.0",
     "colors": "^1.1.2",
-    "discord.js": "^10.0.1",
+    "discord.js": "^11.1.0",
     "lodash": "^4.16.6",
     "log4js": "^1.0.0",
     "request": "^2.76.0",

--- a/package.json
+++ b/package.json
@@ -26,8 +26,7 @@
     "lodash": "^4.16.6",
     "log4js": "^1.0.0",
     "request": "^2.76.0",
-    "request-promise-native": "^1.0.3",
-    "tty-table": "^2.2.5"
+    "request-promise-native": "^1.0.3"
   },
   "devDependencies": {
     "chai": "^3.5.0",

--- a/server.js
+++ b/server.js
@@ -6,7 +6,7 @@ require('colors');
 
 log.setLevel(process.env.LOG_LEVEL || "INFO");
 
-const commandChar = process.env.COMMAND_CHAR || "!"; // should be ideally a single character
+const commandChar = process.env.COMMAND_CHAR || "!";
 const spamTimeout = 3000; // milliseconds
 const modules = [
     'rules/mtr',
@@ -40,7 +40,7 @@ bot.on("message", msg => {
     // Example: ^!(card|price) ?(.*)$|!(card|price) ?([^!]*)(!|$)
     const charPattern = _.escapeRegExp(commandChar);
     const commandPattern = charPattern+'('+Object.keys(handlers).map(_.escapeRegExp).join('|')+')';
-    const regExpPattern = `${commandPattern} ?([^${charPattern}]*)(${charPattern}|$)`;
+    const regExpPattern = `${commandPattern} ?(.*?)(${charPattern}[^a-z0-9]|$)`;
 
     const queries = msg.content.match(new RegExp(regExpPattern, 'ig')) || [];
     const lastMessage = userMessageTimes[msg.author.id] || 0;

--- a/server.js
+++ b/server.js
@@ -6,7 +6,7 @@ require('colors');
 
 log.setLevel(process.env.LOG_LEVEL || "INFO");
 
-const commandChar = process.env.COMMAND_CHAR || "!"; // single character
+const commandChar = process.env.COMMAND_CHAR || "!"; // should be ideally a single character
 const spamTimeout = 3000; // milliseconds
 const modules = [
     'rules/mtr',
@@ -40,7 +40,7 @@ bot.on("message", msg => {
     // Example: ^!(card|price) ?(.*)$|!(card|price) ?([^!]*)(!|$)
     const charPattern = _.escapeRegExp(commandChar);
     const commandPattern = charPattern+'('+Object.keys(handlers).map(_.escapeRegExp).join('|')+')';
-    const regExpPattern = `^${commandPattern} ?(.*)$|${commandPattern} ?([^${charPattern}]*)(${charPattern}|$)`;
+    const regExpPattern = `${commandPattern} ?([^${charPattern}]*)(${charPattern}|$)`;
 
     const queries = msg.content.match(new RegExp(regExpPattern, 'ig')) || [];
     const lastMessage = userMessageTimes[msg.author.id] || 0;
@@ -92,6 +92,7 @@ bot.on('guildDelete', (guild) => {
 
 bot.login(process.env.DISCORD_TOKEN);
 
+// send updated stats to bots.discord.com
 const updateServerCount = () => {
     const options = {
         url: 'https://bots.discord.pw/api/bots/240537940378386442/stats',

--- a/server.js
+++ b/server.js
@@ -1,10 +1,12 @@
 const Discord = require("discord.js");
-const colors = require('colors');
 const request = require("request");
 const log = require("log4js").getLogger('bot');
+const _ = require("lodash");
+require('colors');
+
 log.setLevel(process.env.LOG_LEVEL || "INFO");
 
-const commandChar = process.env.COMMAND_CHAR || "!";
+const commandChar = process.env.COMMAND_CHAR || "!"; // single character
 const spamTimeout = 3000; // milliseconds
 const modules = [
     'rules/mtr',
@@ -34,29 +36,41 @@ const userMessageTimes = {};
 
 /* Handle incoming messages */
 bot.on("message", msg => {
-    const query = msg.content.substr(commandChar.length).split(" ");
-    const command = query[0].toLowerCase();
-    const parameter = query.length > 1 ? query.slice(1).join(" ") : "";
+    // generate RegExp pattern for message parsing
+    // Example: ^!(card|price) ?(.*)$|!(card|price) ?([^!]*)(!|$)
+    const charPattern = _.escapeRegExp(commandChar);
+    const commandPattern = charPattern+'('+Object.keys(handlers).map(_.escapeRegExp).join('|')+')';
+    const regExpPattern = `^${commandPattern} ?(.*)$|${commandPattern} ?([^${charPattern}]*)(${charPattern}|$)`;
+
+    const queries = msg.content.match(new RegExp(regExpPattern, 'ig')) || [];
     const lastMessage = userMessageTimes[msg.author.id] || 0;
 
+    // check if it's a message for us
     if (bot.user.id === msg.author.id || // don't message yourself
-        msg.content.substr(0, commandChar.length) != commandChar || // not the right command char
-        !handlers[command] || // no handler for this command
+        !queries.length || // no commands entered
         new Date().getTime() - lastMessage < spamTimeout) { // too spammy
         return;
     }
 
-    let logMessage = [
-        '[' + (msg.guild ? msg.guild.name.blue : 'private query') + ']',
-        msg.channel.name ? '[' + msg.channel.name + ']' : '',
-        msg.author.username.blue + '#' + msg.author.discriminator.blue,
-        'used', command.green, parameter.yellow
-    ];
-    log.info(logMessage.join(' '));
+    // store the time to prevent spamming from this user
     userMessageTimes[msg.author.id] = new Date().getTime();
-    const ret = handlers[command].handleMessage(command, parameter, msg);
-    // if ret is undefined or not a thenable this just returns a resolved promise and the callback won't be called
-    Promise.resolve(ret).catch(e => log.error('An error occured while handling', msg.content.green, ":\n", e));
+
+    // only use the first 3 commands in a message, ignore the rest
+    queries.slice(0,3).forEach(query => {
+        const command = query.split(" ")[0].substr(commandChar.length).toLowerCase();
+        const parameter = query.split(" ").slice(1).join(" ").replace(new RegExp(charPattern+'$', 'i'),'');
+
+        let logMessage = [
+            '[' + (msg.guild ? msg.guild.name.blue : 'private query') + ']',
+            msg.channel.name ? '[' + msg.channel.name + ']' : '',
+            msg.author.username.blue + '#' + msg.author.discriminator.blue,
+            'used', command.green, parameter.yellow
+        ];
+        log.info(logMessage.join(' '));
+        const ret = handlers[command].handleMessage(command, parameter, msg);
+        // if ret is undefined or not a thenable this just returns a resolved promise and the callback won't be called
+        Promise.resolve(ret).catch(e => log.error('An error occured while handling', msg.content.green, ":", e.message));
+    })
 });
 
 /* Bot event listeners */

--- a/test/rules/mtr.js
+++ b/test/rules/mtr.js
@@ -32,12 +32,12 @@ describe('MTR', function () {
                 mtr.cleanup($);
                 expect($('.section-header').length).to.equal(3);
             });
-            it('should mark appendices as sections', function () {
-                 const $ = cheerio.load('<body><h4>1. A Chapter</h4><h4>1.1 A Section</h4><p>Some Content</p><h4>Appendix A-An Appendix</h4><p>More content</p></body>');
-                 mtr.cleanup($);
-                 expect($('.section-header').length).to.equal(2);
-                 expect($('.section-header').last().text()).to.equal('Appendix A-An Appendix');
-            });
+            // it('should mark appendices as sections', function () {
+            //      const $ = cheerio.load('<body><h4>1. A Chapter</h4><h4>1.1 A Section</h4><p>Some Content</p><h4>Appendix A-An Appendix</h4><p>More content</p></body>');
+            //      mtr.cleanup($);
+            //      expect($('.section-header').length).to.equal(2);
+            //      expect($('.section-header').last().text()).to.equal('Appendix A-An Appendix');
+            // });
         });
         describe('#handleChapter', function () {
             it('should produce chapter entries for each chapter', function () {
@@ -63,13 +63,13 @@ describe('MTR', function () {
            
                 expect(mtr.mtrData.sections).to.have.deep.property('1\\.2.title', '1.2 Another Section');
             });
-            it('should produce section entries for appendices', function () {
-                expect(mtr.mtrData.sections).to.have.deep.property('appendix-a.title', 'Appendix A-An Appendix');
-            });
+            // it('should produce section entries for appendices', function () {
+            //     expect(mtr.mtrData.sections).to.have.deep.property('appendix-a.title', 'Appendix A-An Appendix');
+            // });
             it('should add section entries to the appropriate chapter', function () {
                 expect(mtr.mtrData.chapters).to.have.deep.property('1.sections[0]', '1.1');
                 expect(mtr.mtrData.chapters).to.have.deep.property('1.sections[1]', '1.2');
-                expect(mtr.mtrData.chapters).to.have.deep.property('appendices.sections[0]', 'appendix-a'); 
+                // expect(mtr.mtrData.chapters).to.have.deep.property('appendices.sections[0]', 'appendix-a');
             });
         });
         describe('#handleSectionContent', function () {
@@ -78,21 +78,21 @@ describe('MTR', function () {
                 const result = mtr.handleSectionContent($, $('.section-header').first(), "1.1 A Section", "1.1");
                 expect(result).to.equal('Some section content\n\nMore section content');
             });
-            it('should handle tables', function () {
-                const $ = cheerio.load([
-                    '<body><h4 class="section-header">1.1 A Section</h4><p>Some section content\n</p>',
-                    '<table><tr><th>col1header</th><th>col2header</th></tr>',
-                    '<tr><td>col1content</td><td>col2content</td></tr></table>'
-                ].join('\n'));
-
-                const result = mtr.handleSectionContent($, $('.section-header').first(), "1.1 A Section", "1.1");
-                const tableData = [
-                    ['col1header', 'col2header'],
-                    ['col1content', 'col2content']
-                ]
-                const textTable = new Table(null, tableData).render().split('\n').filter(l => l.trim().length !== 0).map(l => '`' + l + '`').join('\n');
-                expect(result).to.equal('Some section content\n\n' + textTable);
-            });
+            // it('should handle tables', function () {
+            //     const $ = cheerio.load([
+            //         '<body><h4 class="section-header">1.1 A Section</h4><p>Some section content\n</p>',
+            //         '<table><tr><th>col1header</th><th>col2header</th></tr>',
+            //         '<tr><td>col1content</td><td>col2content</td></tr></table>'
+            //     ].join('\n'));
+            //
+            //     const result = mtr.handleSectionContent($, $('.section-header').first(), "1.1 A Section", "1.1");
+            //     const tableData = [
+            //         ['col1header', 'col2header'],
+            //         ['col1content', 'col2content']
+            //     ]
+            //     const textTable = new Table(null, tableData).render().split('\n').filter(l => l.trim().length !== 0).map(l => '`' + l + '`').join('\n');
+            //     expect(result).to.equal('Some section content\n\n' + textTable);
+            // });
         });
     });
     describe('output', function () {
@@ -102,10 +102,10 @@ describe('MTR', function () {
                 const result = mtr.generateLink('3.5');
                 expect(result).to.equal(rulesBlogMTR + '3-5');
             });
-            it('should work for appendices', function () {
-                const result = mtr.generateLink('appendix-c');
-                expect(result).to.equal(rulesBlogMTR + '-appendix-c');
-            });
+            // it('should work for appendices', function () {
+            //     const result = mtr.generateLink('appendix-c');
+            //     expect(result).to.equal(rulesBlogMTR + '-appendix-c');
+            // });
         });
         describe('#formatChapter', function () {
             let chapter;
@@ -154,7 +154,7 @@ describe('MTR', function () {
             expect(mtr.mtrData.chapters).to.have.keys(_.flatten([_.range(1, 11).map(_.toString), 'appendices']));
 
             expect(mtr.mtrData.sections).to.contain.keys(_.range(1, 11).map(n => `${n}.1`));
-            expect(mtr.mtrData.sections).to.contain.key('appendix-b');
+            // expect(mtr.mtrData.sections).to.contain.key('appendix-b');
         });
 
          describe('#find', function() {
@@ -164,9 +164,9 @@ describe('MTR', function () {
             it('should work for section queries', function() {
                 expect(mtr.find('4.4')).to.contain('Players are expected to remember their own triggered abilities');
             });
-            it('should work for appendix queries', function () {
-                expect(mtr.find('appendix-b')).to.contain('Time Limits')
-            });
+            // it('should work for appendix queries', function () {
+            //     expect(mtr.find('appendix-b')).to.contain('Time Limits')
+            // });
             
             it('should give an error on unknown chapters', function() {
                 expect(mtr.find('11')).to.contain('not exist').and.to.contain('Available Chapters');

--- a/test/rules/mtr.js
+++ b/test/rules/mtr.js
@@ -3,7 +3,6 @@ const MTR = require('../../modules/rules/mtr');
 const _ = require('lodash');
 const chai = require('chai');
 const cheerio = require('cheerio');
-const Table = require('tty-table')
 const fs = require('fs');
 
 const expect = chai.expect;
@@ -32,12 +31,6 @@ describe('MTR', function () {
                 mtr.cleanup($);
                 expect($('.section-header').length).to.equal(3);
             });
-            // it('should mark appendices as sections', function () {
-            //      const $ = cheerio.load('<body><h4>1. A Chapter</h4><h4>1.1 A Section</h4><p>Some Content</p><h4>Appendix A-An Appendix</h4><p>More content</p></body>');
-            //      mtr.cleanup($);
-            //      expect($('.section-header').length).to.equal(2);
-            //      expect($('.section-header').last().text()).to.equal('Appendix A-An Appendix');
-            // });
         });
         describe('#handleChapter', function () {
             it('should produce chapter entries for each chapter', function () {
@@ -63,13 +56,9 @@ describe('MTR', function () {
            
                 expect(mtr.mtrData.sections).to.have.deep.property('1\\.2.title', '1.2 Another Section');
             });
-            // it('should produce section entries for appendices', function () {
-            //     expect(mtr.mtrData.sections).to.have.deep.property('appendix-a.title', 'Appendix A-An Appendix');
-            // });
             it('should add section entries to the appropriate chapter', function () {
                 expect(mtr.mtrData.chapters).to.have.deep.property('1.sections[0]', '1.1');
                 expect(mtr.mtrData.chapters).to.have.deep.property('1.sections[1]', '1.2');
-                // expect(mtr.mtrData.chapters).to.have.deep.property('appendices.sections[0]', 'appendix-a');
             });
         });
         describe('#handleSectionContent', function () {
@@ -78,21 +67,6 @@ describe('MTR', function () {
                 const result = mtr.handleSectionContent($, $('.section-header').first(), "1.1 A Section", "1.1");
                 expect(result).to.equal('Some section content\n\nMore section content');
             });
-            // it('should handle tables', function () {
-            //     const $ = cheerio.load([
-            //         '<body><h4 class="section-header">1.1 A Section</h4><p>Some section content\n</p>',
-            //         '<table><tr><th>col1header</th><th>col2header</th></tr>',
-            //         '<tr><td>col1content</td><td>col2content</td></tr></table>'
-            //     ].join('\n'));
-            //
-            //     const result = mtr.handleSectionContent($, $('.section-header').first(), "1.1 A Section", "1.1");
-            //     const tableData = [
-            //         ['col1header', 'col2header'],
-            //         ['col1content', 'col2content']
-            //     ]
-            //     const textTable = new Table(null, tableData).render().split('\n').filter(l => l.trim().length !== 0).map(l => '`' + l + '`').join('\n');
-            //     expect(result).to.equal('Some section content\n\n' + textTable);
-            // });
         });
     });
     describe('output', function () {
@@ -102,10 +76,6 @@ describe('MTR', function () {
                 const result = mtr.generateLink('3.5');
                 expect(result).to.equal(rulesBlogMTR + '3-5');
             });
-            // it('should work for appendices', function () {
-            //     const result = mtr.generateLink('appendix-c');
-            //     expect(result).to.equal(rulesBlogMTR + '-appendix-c');
-            // });
         });
         describe('#formatChapter', function () {
             let chapter;
@@ -154,7 +124,6 @@ describe('MTR', function () {
             expect(mtr.mtrData.chapters).to.have.keys(_.flatten([_.range(1, 11).map(_.toString), 'appendices']));
 
             expect(mtr.mtrData.sections).to.contain.keys(_.range(1, 11).map(n => `${n}.1`));
-            // expect(mtr.mtrData.sections).to.contain.key('appendix-b');
         });
 
          describe('#find', function() {
@@ -164,10 +133,7 @@ describe('MTR', function () {
             it('should work for section queries', function() {
                 expect(mtr.find('4.4')).to.contain('Players are expected to remember their own triggered abilities');
             });
-            // it('should work for appendix queries', function () {
-            //     expect(mtr.find('appendix-b')).to.contain('Time Limits')
-            // });
-            
+
             it('should give an error on unknown chapters', function() {
                 expect(mtr.find('11')).to.contain('not exist').and.to.contain('Available Chapters');
             });


### PR DESCRIPTION
- Any command can be used inline with a secondary closing char now, for example:
`<user> I need !card garruk! and !card tarmogoyf! for the PPTQ` will show both Garruk and Tarmogoyf cards. Commands can be mixed and the bot supports up to 3 commands in one message.
- Rendering of !card is now handled through RichEmbeds and uses custom Manamoji, which looks *much* nicer
- Card data is fetched from Scryfall API now, which supports a truckload of custom syntax
- support for !price, !legal and !ruling to show more info for a card
- MTR output is rendered with RichEmbeds now as well, appendices have been dropped
- IPG output is rendered with RichEmbeds, some small bugs have been fixed there, too
- CR output is rendered with RichEmbeds and pulls subrules now as well