### PR TITLE
Allow direct guessing in hangman

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ For example: `I'm looking for !card tarmogoyf! and !card noble hierarch` would s
 - **!ruling \<partial cardname\>**: searches for an (English) card by name and outputs the Gatherer rulings for that card, *Example: !ruling Tarmogoyf*
 - **!stores \<location name\>**: searches for the closest Magic stores near the provided location, *Example: !stores new york*
 - **!events \<store name\>**: shows the next 6 Magic events for the provided store, *Example: !events funtainment*
-- **!hangman \<easy|medium|hard\>**: starts a game of Hangman where you guess a Magic card name with Discord reactions, *Example: !hangman easy*
+- **!hangman \<easy|medium|hard\>**: starts a game of Hangman where you guess a Magic card name with Discord reactions and the guess command, *Example: !hangman easy*
+    - **!hangman guess <cardname>**: makes an outright guess of the target card in an existing  game of Hangman, *Example: !hangman guess yare*
 - **!standard**: shows all sets that are currently legal in Standard
 - **!cr \<paragraph number\>**: shows the chosen paragraph from the [Comprehensive Rules](https://rules.wizards.com/rulebook.aspx?game=Magic&category=Game+Rules), *Example: !cr 100.6b*
 - **!define \<keyword\>**: shows the chosen keyword definition from the [Comprehensive Rules](https://rules.wizards.com/rulebook.aspx?game=Magic&category=Game+Rules), *Example: !define banding*

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ For example: `I'm looking for !card tarmogoyf! and !card noble hierarch` would s
 - **!stores \<location name\>**: searches for the closest Magic stores near the provided location, *Example: !stores new york*
 - **!events \<store name\>**: shows the next 6 Magic events for the provided store, *Example: !events funtainment*
 - **!hangman \<easy|medium|hard\>**: starts a game of Hangman where you guess a Magic card name with Discord reactions and the guess command, *Example: !hangman easy*
-    - **!hangman guess <cardname>**: makes an outright guess of the target card in an existing  game of Hangman, *Example: !hangman guess yare*
+    - **!hangman guess \<cardname\>**: makes an outright guess of the target card in an existing  game of Hangman, *Example: !hangman guess yare*
 - **!standard**: shows all sets that are currently legal in Standard
 - **!cr \<paragraph number\>**: shows the chosen paragraph from the [Comprehensive Rules](https://rules.wizards.com/rulebook.aspx?game=Magic&category=Game+Rules), *Example: !cr 100.6b*
 - **!define \<keyword\>**: shows the chosen keyword definition from the [Comprehensive Rules](https://rules.wizards.com/rulebook.aspx?game=Magic&category=Game+Rules), *Example: !define banding*

--- a/modules/hangman.js
+++ b/modules/hangman.js
@@ -10,13 +10,15 @@ const GAME_TIME = 3*60*1000; // minutes
 
 class HangmanGame {
     constructor({
-                    id ,
+                    id,
+                    gameList,
                     message = null,
                     collector = null,
                     card = null,
                     difficulty = 'medium',
                 } = {}) {
         this.id = id;
+        this.gameList = gameList;
         this.message = message;
         this.collector = collector;
         this.card = card;
@@ -75,6 +77,9 @@ class HangmanGame {
         this.done = true;
         this.updateEmbed();
         this.collector.stop('finished');
+        
+        // remove guild / author ID from running games
+        delete this.gameList[this.id];
     }
 
     /**
@@ -248,7 +253,8 @@ class MtgHangman {
         // Create the new game
         const game = this.runningGames[id] = new HangmanGame({
             id: id,
-            difficulty: first
+            difficulty: first,
+            gameList: this.runningGames
         });
 
         // fetch data from API
@@ -267,12 +273,7 @@ class MtgHangman {
                         const char = String.fromCharCode(reaction.emoji.name.charCodeAt(1) - 56709);
                         game.handleLetter(char);
                     }).on('end', (collected, reason) => {
-                        // game is already over, don't edit message again
-                        if (reason !== "finished") {
-                            game.setDone();
-                        }
-                        // remove guild / author ID from running games
-                        delete this.runningGames[id];
+                        game.setDone();
                     });
                     
                     // Update the game object with pertinent information

--- a/modules/hangman.js
+++ b/modules/hangman.js
@@ -105,7 +105,7 @@ class MtgHangman {
             const game = this.runningGames[id];
             // The user can !hangman guess Some Card Name
             if (first === 'guess'){
-                const correct = this.runningGames[id].body.name.toLowerCase();
+                const correct = game.card.name.toLowerCase();
                 const guess = rest.join(' ').toLowerCase();
                 if (guess.includes(correct)){
                     // If they're correct, pretend we guessed all the letters individually

--- a/modules/hangman.js
+++ b/modules/hangman.js
@@ -1,12 +1,12 @@
-const rp = require("request-promise-native");
-const _ = require("lodash");
-const Discord = require("discord.js");
-const utils = require("../utils");
+const rp = require('request-promise-native');
+const _ = require('lodash');
+const Discord = require('discord.js');
+const utils = require('../utils');
 const log = utils.getLogger('hangman');
-const Card = require("./card");
+const Card = require('./card');
 const cardFetcher = new Card();
 
-const GAME_TIME = 3*60*1000; // minutes
+const GAME_TIME = 3 * 60 * 1000; // minutes
 
 class HangmanGame {
     constructor({
@@ -23,17 +23,18 @@ class HangmanGame {
         this.collector = collector;
         this.card = card;
         this.difficulty = difficulty;
-        
+
         this.letters = new Set();
         this.wrongGuesses = 0;
         this.done = false;
+        this.gameSuccess = false;
     }
 
     /**
      * Handle a user guessing a letter in the word
      * @param {String} char The character that was guessed
      */
-    handleLetter(char){
+    handleLetter(char) {
         // get emoji character (we only accept :regional_indicator_X: emojis)
         this.letters.add(char);
         this.checkDone();
@@ -45,19 +46,18 @@ class HangmanGame {
      * @param {String} guess
      * @param {Discord.Message} msg
      */
-    handleGuess(guess, msg){
+    handleGuess(guess, msg) {
         const correct = this.card.name.toLowerCase();
-        if (guess.includes(correct)){
+        if (guess.includes(correct)) {
             // If they're correct, pretend we guessed all the letters individually
-            this.updateEmbed(true);
-            this.collector.stop('finished');
-            this.setDone();
+            this.setDone(true);
+            this.updateEmbed();
         }
         else {
             this.wrongGuesses++;
-            msg.react('❎');
             this.checkDone();
-            this.updateEmbed(false);
+            msg.react('❎');
+            this.updateEmbed();
         }
     }
 
@@ -65,19 +65,23 @@ class HangmanGame {
      * Checks if the game should finish
      */
     checkDone() {
-        if ((!this.missing.length) || this.wrong > 6) {
-            this.setDone();
+        if (!this.missing.length) {
+            this.setDone(true);
+        }
+        if (this.wrong > 6) {
+            this.setDone(false);
         }
     }
 
     /**
      * Indicates that this game is finished
      */
-    setDone(){
+    setDone(correct = false) {
         this.done = true;
+        this.gameSuccess = correct;
         this.updateEmbed();
         this.collector.stop('finished');
-        
+
         // remove guild / author ID from running games
         delete this.gameList[this.id];
     }
@@ -86,7 +90,7 @@ class HangmanGame {
      * Using the stored parameters, updates the embed for the specified game
      * @param {Boolean} forceCorrect If true, force the game to be won
      */
-    updateEmbed(forceCorrect = false){
+    updateEmbed(forceCorrect = false) {
         this.message.edit('', {embed: this.generateEmbed(forceCorrect)});
     }
 
@@ -94,7 +98,7 @@ class HangmanGame {
      * An array of letters that have not yet been guessed
      * @returns {Array}
      */
-    get missing(){
+    get missing() {
         const letterArr = Array.from(this.letters.values());
         return _.difference(_.uniq(this.card.name.replace(/[^a-z]/ig, '').toLowerCase().split('')), letterArr);
     }
@@ -103,13 +107,13 @@ class HangmanGame {
      * The number of wrong guesses made in this game
      * @returns {number}
      */
-    get wrong(){
+    get wrong() {
         const letterArr = Array.from(this.letters.values());
-        
+
         // The total number of mistakes is the sum of the incorrect letters, and incorrect guesses
         return letterArr.filter(c => this.card.name.toLowerCase().indexOf(c) === -1).length + this.wrongGuesses;
     }
-    
+
     /**
      * Return a discord Embed derived from this game
      * @param {Boolean} forceCorrect If true, force the game to be won
@@ -136,8 +140,8 @@ class HangmanGame {
         const correctPercent = Math.round((1 - (wrong / (totalGuesses || 1))) * 100);
 
         // generate embed title
-        const title = this.card.name.replace(/[a-z]/ig, c => !this.letters.has(c.toLowerCase()) ? '⬚':c);
-        let description = "";
+        const title = this.card.name.replace(/[a-z]/ig, c => !this.letters.has(c.toLowerCase()) ? '⬚' : c);
+        let description = '';
         // hard is without mana cost
         if (this.difficulty !== 'hard') {
             description += cardFetcher.renderEmojis(this.card.mana_cost) + '\n';
@@ -150,10 +154,10 @@ class HangmanGame {
         description += '```\n' +
             '   ____     \n' +
             `  |    |    Missing: ${missing.length} letter(s)\n` +
-            `  |    ${wrong > 0 ? 'o':' '}    Guessed: ${letterArr.join("").toUpperCase()}\n` +
-            `  |   ${wrong > 2 ? '/':' '}${wrong > 1 ? '|':' '}${wrong > 3 ? '\\':' '}   Correct: ${correctPercent}%\n` +
-            `  |    ${wrong > 1 ? '|':' '}    \n` +
-            `  |   ${wrong > 4 ? '/':' '} ${wrong > 5 ? '\\':' '}   \n` +
+            `  |    ${wrong > 0 ? 'o' : ' '}    Guessed: ${letterArr.join('').toUpperCase()}\n` +
+            `  |   ${wrong > 2 ? '/' : ' '}${wrong > 1 ? '|' : ' '}${wrong > 3 ? '\\' : ' '}   Correct: ${correctPercent}%\n` +
+            `  |    ${wrong > 1 ? '|' : ' '}    \n` +
+            `  |   ${wrong > 4 ? '/' : ' '} ${wrong > 5 ? '\\' : ' '}   \n` +
             ' _|________\n```\n' +
             'Use :regional_indicator_a::regional_indicator_b::regional_indicator_c: ... :regional_indicator_z: ' +
             'reactions to pick letters.';
@@ -169,14 +173,15 @@ class HangmanGame {
         // game is over
         if (this.done) {
             embed.setTitle(this.card.name);
-            embed.setFooter(missing.length ? 'You failed to guess the card!':'You guessed the card!');
+            embed.setFooter(this.gameSuccess ? 'You guessed the card!' :'You failed to guess the card!');
             embed.setURL(this.card.scryfall_uri);
             if (this.card.layout === 'transform' && this.card.card_faces && this.card.card_faces[0].image_uris) {
                 embed.setImage(this.card.card_faces[0].image_uris.normal);
-            } else if(this.card.image_uris) {
+            }
+            else if (this.card.image_uris) {
                 embed.setImage(this.card.image_uris.normal);
             }
-            embed.setColor(missing.length ? 0xff0000 : 0x00ff00);
+            embed.setColor(this.gameSuccess ? 0x00ff00 : 0xff0000);
         }
 
         return embed;
@@ -191,20 +196,20 @@ class MtgHangman {
                 inline: false,
                 description: 'Start a game of hangman, where you have to guess the card name with reaction letters',
                 help: 'Selects a random Magic card, token or plane and shows you the ' +
-                'placeholders for each letter in its name. To guess a letter, add a reaction to the ' +
-                'Hangman-message of the bot. Reactions have to be selected among the regional indicators ' +
-                ':regional_indicator_a: to :regional_indicator_z:. You can also use `!hangman guess some card` ' +
-                'to guess the card outright, but guessing wrongly will be penalised the same as a wrong letter. ' +
-                'You can only have one active game of ' +
-                'Hangman per Discord server, but you can also start an additional one in a private query.\n\n' +
-                '**Difficulty**:\n' +
-                'With an optional parameter you can select the difficulty. Available are `easy`, `medium` ' +
-                'and `hard`. Default is medium. "Easy" includes the mana cost and type line, "Medium" includes ' +
-                'the mana cost and "Hard" doesn\'t include any hints.',
-                examples: ["!hangman", "!hangman easy", "!hangman guess yare"]
+                    'placeholders for each letter in its name. To guess a letter, add a reaction to the ' +
+                    'Hangman-message of the bot. Reactions have to be selected among the regional indicators ' +
+                    ':regional_indicator_a: to :regional_indicator_z:. You can also use `!hangman guess some card` ' +
+                    'to guess the card outright, but guessing wrongly will be penalised the same as a wrong letter. ' +
+                    'You can only have one active game of ' +
+                    'Hangman per Discord server, but you can also start an additional one in a private query.\n\n' +
+                    '**Difficulty**:\n' +
+                    'With an optional parameter you can select the difficulty. Available are `easy`, `medium` ' +
+                    'and `hard`. Default is medium. "Easy" includes the mana cost and type line, "Medium" includes ' +
+                    'the mana cost and "Hard" doesn\'t include any hints.',
+                examples: ['!hangman', '!hangman easy', '!hangman guess yare']
             }
         };
-        this.cardApi = "https://api.scryfall.com/cards/random";
+        this.cardApi = 'https://api.scryfall.com/cards/random';
         this.runningGames = {};
     }
 
@@ -215,34 +220,35 @@ class MtgHangman {
     // generate the embed card
 
     handleMessage(command, parameter, msg) {
-        const [first, ...rest] = parameter.toLowerCase().split(" ");
+        const [first, ...rest] = parameter.toLowerCase().split(' ');
 
         // check for already running games
         const id = msg.guild ? msg.guild.id : msg.author.id;
         if (id in this.runningGames) {
             const game = this.runningGames[id];
             // The user can !hangman guess Some Card Name
-            if (first === 'guess'){
+            if (first === 'guess') {
                 const guess = rest.join(' ').toLowerCase();
                 game.handleGuess(guess, msg);
             }
             else {
                 msg.channel.send('', {
                     embed: new Discord.MessageEmbed({
-                        title: "Error",
-                        description: "You can only start one hangman game every " + GAME_TIME / 60000 + " minutes.",
+                        title: 'Error',
+                        description: 'You can only start one hangman game every ' + GAME_TIME / 60000 + ' minutes.',
                         color: 0xff0000
                     })
                 });
             }
             return;
-        } else {
+        }
+        else {
             // Handle the case where we "!hangman guess" but no game has started
             if (first === 'guess') {
                 msg.channel.send('', {
                     embed: new Discord.MessageEmbed({
-                        title: "Error",
-                        description: "No hangman game is currently running in this server. Guess ignored.",
+                        title: 'Error',
+                        description: 'No hangman game is currently running in this server. Guess ignored.',
                         color: 0xff0000
                     })
                 });
@@ -275,20 +281,24 @@ class MtgHangman {
                     }).on('end', (collected, reason) => {
                         game.setDone();
                     });
-                    
+
                     // Update the game object with pertinent information
                     game.collector = collector;
-                }).catch(() => {});
+                }).catch(() => {
+                });
             }
         }, err => {
-            log.error("Error getting random card from API", err.error.details);
-            msg.channel.send('', {embed: new Discord.MessageEmbed({
-                title: "Error",
-                description: "Scryfall is currently offline and can't generate us a random card, please try again later.",
-                color: 0xff0000
-            })});
+            log.error('Error getting random card from API', err.error.details);
+            msg.channel.send('', {
+                embed: new Discord.MessageEmbed({
+                    title: 'Error',
+                    description: 'Scryfall is currently offline and can\'t generate us a random card, please try again later.',
+                    color: 0xff0000
+                })
+            });
             delete this.runningGames[id];
-        }).catch(() => {});
+        }).catch(() => {
+        });
     }
 }
 

--- a/modules/hangman.js
+++ b/modules/hangman.js
@@ -211,6 +211,7 @@ class MtgHangman {
                         color: 0xff0000
                     })
                 });
+                return;
             }
         }
 

--- a/modules/hangman.js
+++ b/modules/hangman.js
@@ -80,7 +80,7 @@ class HangmanGame {
         this.done = true;
         this.gameSuccess = correct;
         this.updateEmbed();
-        this.collector.stop('finished');
+        this.collector.stop('cancelled');
 
         // remove guild / author ID from running games
         delete this.gameList[this.id];
@@ -279,7 +279,10 @@ class MtgHangman {
                         const char = String.fromCharCode(reaction.emoji.name.charCodeAt(1) - 56709);
                         game.handleLetter(char);
                     }).on('end', (collected, reason) => {
-                        game.setDone();
+                        // If we cancelled the collector, the game state has already been updated
+                        // If the time ran out, however, we know that the game was lost
+                        if (reason === 'time')
+                            game.setDone(false);
                     });
 
                     // Update the game object with pertinent information

--- a/modules/hangman.js
+++ b/modules/hangman.js
@@ -31,11 +31,11 @@ class HangmanGame {
     }
 
     /**
-     * Handle a user guessing a letter in the word
+     * Handle a user guessing a letter in the card name
      * @param {String} char The character that was guessed
      */
     handleLetter(char) {
-        // get emoji character (we only accept :regional_indicator_X: emojis)
+        // Letters is a set, which handles duplicates for us
         this.letters.add(char);
         this.checkDone();
         this.updateEmbed(false);
@@ -88,10 +88,9 @@ class HangmanGame {
 
     /**
      * Using the stored parameters, updates the embed for the specified game
-     * @param {Boolean} forceCorrect If true, force the game to be won
      */
-    updateEmbed(forceCorrect = false) {
-        this.message.edit('', {embed: this.generateEmbed(forceCorrect)});
+    updateEmbed() {
+        this.message.edit('', {embed: this.generateEmbed()});
     }
 
     /**
@@ -116,26 +115,14 @@ class HangmanGame {
 
     /**
      * Return a discord Embed derived from this game
-     * @param {Boolean} forceCorrect If true, force the game to be won
      * @returns {module:"discord.js".MessageEmbed}
      */
-    generateEmbed(forceCorrect = false) {
-        // count number of wrong letters and missing letters
-        let missing;
-        let wrong;
+    generateEmbed() {
+        const missing = this.missing;
+        const wrong = this.wrong;
         let totalGuesses = this.letters.size + this.wrongGuesses;
 
         const letterArr = Array.from(this.letters.values());
-
-        // Allow guessing to force the correct answer
-        if (forceCorrect) {
-            missing = [];
-            wrong = 0;
-        }
-        else {
-            missing = this.missing;
-            wrong = this.wrong;
-        }
 
         const correctPercent = Math.round((1 - (wrong / (totalGuesses || 1))) * 100);
 

--- a/modules/hangman.js
+++ b/modules/hangman.js
@@ -34,6 +34,16 @@ class MtgHangman {
         return this.commands;
     }
 
+    /**
+     * Using the stored parameters, updates the embed for the specified game
+     * @param id Game ID
+     * @param forceCorrect If true, force the game to be won
+     */
+    updateEmbed(id, forceCorrect = false){
+        const game = this.runningGames[id];
+        game.message.edit('', {embed: this.generateEmbed(game.card, game.difficulty, game.letters, game.done, forceCorrect, game.wrongGuesses)});
+    }
+
     // generate the embed card
     generateEmbed(card, difficulty, letters = [], done = false, forceCorrect = false, wrongGuesses = 0) {
         // count number of wrong letters and missing letters
@@ -109,21 +119,14 @@ class MtgHangman {
                 const guess = rest.join(' ').toLowerCase();
                 if (guess.includes(correct)){
                     // If they're correct, pretend we guessed all the letters individually
-                    const embed = this.generateEmbed(
-                        game.card,
-                        game.difficulty,
-                        game.letters,
-                        true,
-                        true,
-                        game.wrongGuesses
-                    );
-                    game.message.edit('', {embed});
+                    this.updateEmbed(id, true);
                     game.collector.stop('finished');
                     msg.react('✅');
                 }
                 else {
                     game.wrongGuesses++;
                     msg.react('❎');
+                    this.updateEmbed(id, false);
                 }
             }
             else {
@@ -139,7 +142,7 @@ class MtgHangman {
         }
 
         // Add an empty dict to the running games dictionary so we don't make duplicates
-        this.runningGames[id] = {};
+        const game = this.runningGames[id] = {};
 
         const difficulty = first; // can be "easy" or "hard" or blank (=medium)
 
@@ -159,8 +162,7 @@ class MtgHangman {
                         if (letters.indexOf(char) < 0) {
                             letters.push(char);
                         }
-                        const embed = this.generateEmbed(body, difficulty, letters);
-                        sentMessage.edit('', {embed});
+                        this.updateEmbed(id, false);
                         // is the game over? then stop the collector
                         if (embed.image && embed.image.url) {
                             collector.stop('finished');
@@ -168,7 +170,8 @@ class MtgHangman {
                     }).on('end', (collected, reason) => {
                         // game is already over, don't edit message again
                         if (reason !== "finished") {
-                            sentMessage.edit('', {embed: this.generateEmbed(body, difficulty, letters, true)});
+                            game.done = true;
+                            this.updateEmbed(id, false);
                         }
                         // remove guild / author ID from running games
                         delete this.runningGames[id];
@@ -180,7 +183,8 @@ class MtgHangman {
                         card: body,
                         difficulty: difficulty,
                         letters: letters,
-                        wrongGuesses: 0
+                        wrongGuesses: 0,
+                        done: false
                     };
                 }).catch(() => {});
             }

--- a/modules/hangman.js
+++ b/modules/hangman.js
@@ -158,7 +158,7 @@ class MtgHangman {
                 help: 'Selects a random Magic card, token or plane and shows you the ' +
                 'placeholders for each letter in its name. To guess a letter, add a reaction to the ' +
                 'Hangman-message of the bot. Reactions have to be selected among the regional indicators ' +
-                ':regional_indicator_a: to :regional_indicator_z:. You can also use "!hangman guess some card" ' +
+                ':regional_indicator_a: to :regional_indicator_z:. You can also use `!hangman guess some card` ' +
                 'to guess the card outright, but guessing wrongly will be penalised the same as a wrong letter. ' +
                 'You can only have one active game of ' +
                 'Hangman per Discord server, but you can also start an additional one in a private query.\n\n' +

--- a/modules/hangman.js
+++ b/modules/hangman.js
@@ -172,7 +172,7 @@ class MtgHangman {
                 description: "Scryfall is currently offline and can't generate us a random card, please try again later.",
                 color: 0xff0000
             })});
-            _.pull(this.runningGames, id);
+            delete this.runningGames[id];
         }).catch(() => {});
     }
 }

--- a/modules/hangman.js
+++ b/modules/hangman.js
@@ -89,7 +89,7 @@ class HangmanGame {
 
         // Allow guessing to force the correct answer
         if (forceCorrect) {
-            missing = 0;
+            missing = [];
             wrong = 0;
         }
         else {
@@ -155,16 +155,18 @@ class MtgHangman {
                 aliases: [],
                 inline: false,
                 description: 'Start a game of hangman, where you have to guess the card name with reaction letters',
-                help: 'Selects a random Magic card, token oder plane and shows you the ' +
+                help: 'Selects a random Magic card, token or plane and shows you the ' +
                 'placeholders for each letter in its name. To guess a letter, add a reaction to the ' +
                 'Hangman-message of the bot. Reactions have to be selected among the regional indicators ' +
-                ':regional_indicator_a: to :regional_indicator_z:. You can only have one active game of ' +
+                ':regional_indicator_a: to :regional_indicator_z:. You can also use "!hangman guess some card" ' +
+                'to guess the card outright, but guessing wrongly will be penalised the same as a wrong letter. ' +
+                'You can only have one active game of ' +
                 'Hangman per Discord server, but you can also start an additional one in a private query.\n\n' +
                 '**Difficulty**:\n' +
                 'With an optional parameter you can select the difficulty. Available are `easy`, `medium` ' +
                 'and `hard`. Default is medium. "Easy" includes the mana cost and type line, "Medium" includes ' +
                 'the mana cost and "Hard" doesn\'t include any hints.',
-                examples: ["!hangman", "!hangman easy"]
+                examples: ["!hangman", "!hangman easy", "!hangman guess yare"]
             }
         };
         this.cardApi = "https://api.scryfall.com/cards/random";
@@ -199,6 +201,17 @@ class MtgHangman {
                 });
             }
             return;
+        } else {
+            // Handle the case where we "!hangman guess" but no game has started
+            if (first === 'guess') {
+                msg.channel.send('', {
+                    embed: new Discord.MessageEmbed({
+                        title: "Error",
+                        description: "No hangman game is currently running in this server. Guess ignored.",
+                        color: 0xff0000
+                    })
+                });
+            }
         }
 
         // Create the new game


### PR DESCRIPTION
## User-facing Changes
You can now `!hangman guess The Card Name`. The bot will react with a check or cross mark to your guess, and if you get it right, it will mark the hangman post as correct, and end the game.

For example:
![Screenshot from 2020-04-16 22-05-31](https://user-images.githubusercontent.com/5019367/79454385-794a8800-802e-11ea-83c0-d6a68c3c6fbf.png)

## Internal changes
* Modified the list of running games (`this.runningGames`) into a dictionary that maps GameID → GameData. Not only does this allow for more efficient lookups ("does this server have an active game" is now an `O(1)` operation instead of `O(n)`), but having the game data accessible outside of the `ReactionCollector` allows for other forms of input, like the guessing that I've implemented.
This is somewhat more memory intensive, although this data is already being stored in memory, except via closures rather than an object property. So I could rewrite some of the ReactionCollector stuff to remove the use of closure variables and the memory footprint would be no larger than it originally was. I haven't done that yet, however.
* Added a `forceCorrect` parameter to `generateEmbed()`, to allow for shortcutting the answer process
* Used `fields` instead of `description` for adding markdown to the hangman post. This is because `description` doesn't seem to support markdown in the next version of discord.js (which I'm using)