### PR TITLE
Support Ikoria comprehensive rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Clone the Git repository and run the following commands:
 npm install
 export DISCORD_TOKEN="<your Discord bot token>"
 export GOOGLE_TOKEN="<your Google (Maps) API key>"
-export CR_ADDRESS="http://media.wizards.com/2018/downloads/MagicCompRules%2020180608.txt"
+export CR_ADDRESS="https://media.wizards.com/2020/downloads/MagicCompRules%2020200417.txt"
 export IPG_ADDRESS="https://raw.githubusercontent.com/hgarus/mtgdocs/master/docs/ipg.json"
 export MTR_ADDRESS="https://sites.google.com/site/mtgfamiliar/rules/MagicTournamentRules-light.html"
 node server.js

--- a/modules/rules/cr.js
+++ b/modules/rules/cr.js
@@ -6,7 +6,7 @@ const log = utils.getLogger('cr');
 const Discord = require('discord.js');
 
 // Using the current CR as the default, not sure if they actually stick around once new ones are published
-const CR_ADDRESS = process.env.CR_ADDRESS || "https://media.wizards.com/2019/downloads/MagicCompRules%2020191004.txt";
+const CR_ADDRESS = process.env.CR_ADDRESS || "https://media.wizards.com/2020/downloads/MagicCompRules%2020200417.txt";
 
 class CR {
     constructor() {

--- a/modules/rules/cr.js
+++ b/modules/rules/cr.js
@@ -39,7 +39,8 @@ class CR {
     }
 
     initCR(crText) {
-        crText = crText.replace(/\r/g, "");
+        // Standardise all linebreaks. \r\n → \n for pre-2020 rules, but for 2020 we have to \r → \n
+        crText = crText.replace(/\r\n/g, "\n").replace(/\r/g, '\n');
 
         let rulesText = crText.substring(crText.search("\nCredits\n") + 9).trim();
         const glossaryStartIndex = rulesText.search("\nGlossary\n") + 10;
@@ -48,7 +49,7 @@ class CR {
 
         this.glossary = this.parseGlossary(glossaryText);
         this.crData = this.parseRules(rulesText, this.glossary);
-        this.crData.description = crText.substr(0, crText.search("\nIntroduction\n")).match(/effective as of (.*)\./)[1];
+        this.crData.description = crText.match(/effective as of (.*?)\./)[1];
         log.info("CR Ready, effective "+this.crData.description);
     }
 


### PR DESCRIPTION
* Update the suggested CR rules URL to the April 2020 release
* Adjust some of the parsing to handle the fact that the April 2020 rules use `\r` linebreaks, not `\r\n`