### PR TITLE
Add art crop command

### DIFF
--- a/modules/card.js
+++ b/modules/card.js
@@ -364,13 +364,15 @@ class MtgCardLoader {
                 // generate embed
                 this.generateEmbed(body.data, command, permission).then(embed => {
                     return msg.channel.send('', {embed});
-                }, err => log.error(err)).then(sentMessage => {
+                }, err => log.error(err)).then(async sentMessage => {
                     // add reactions for zoom and paging
-                    sentMessage.react('🔍').then(() => {
-                        if (body.data.length > 1) {
-                            sentMessage.react('⬅').then(() => sentMessage.react('➡'));
-                        }
-                    }).catch(() => {});
+                    if (!command.match(/^art/)){
+                      await sentMessage.react('🔍');
+                    }
+                    if (body.data.length > 1) {
+                      await sentMessage.react('⬅');
+                      await sentMessage.react('➡');
+                    }
 
                     const handleReaction = reaction => {
                         if (reaction.emoji.toString() === '⬅') {

--- a/modules/card.js
+++ b/modules/card.js
@@ -230,9 +230,6 @@ class MtgCardLoader {
             }
 
             let description = this.generateDescriptionText(card);
-            if (command.match(/^art/)) {
-                description = '🖌️' + card.artist
-            }
 
             // are we allowed to use custom emojis? cool, then do so, but make sure the title still fits
             if(hasEmojiPermission) {
@@ -248,18 +245,6 @@ class MtgCardLoader {
                 if (cards.length > 6) footer += '; ...';
             }
 
-            // image
-            let image = null
-            let thumbnail = null
-            if (card.image_uris) {
-                if (command.match(/^art/)) {
-                    image = {url: card.image_uris.art_crop}
-                } else {
-                    image = card.zoom ? {url: card.image_uris.normal} : null
-                    thumbnail = {url: card.image_uris.small}
-                }
-            }
-
             // instantiate embed object
             const embed = new Discord.MessageEmbed({
                 title,
@@ -267,8 +252,8 @@ class MtgCardLoader {
                 footer: {text: footer},
                 url: card.scryfall_uri,
                 color: this.getBorderColor(card.layout === 'transform' ? card.card_faces[0]:card),
-                thumbnail: thumbnail,
-                image: image
+                thumbnail: card.image_uris ? {url: card.image_uris.small} : null,
+                image: card.zoom && card.image_uris ? {url: card.image_uris.normal} : null
             });
 
             // show crop art only
@@ -277,7 +262,7 @@ class MtgCardLoader {
                 embed.setDescription('🖌️ ' + card.artist);
                 embed.setThumbnail(null);
             }
-            
+
             // add pricing, if requested
             if (command.match(/^price/) && card.prices) {
                 let prices = [];

--- a/modules/card.js
+++ b/modules/card.js
@@ -35,6 +35,13 @@ class MtgCardLoader {
                 description: "Show the format legality for a card",
                 help: '',
                 examples: ["!legal divining top"]
+            },
+            art: {
+                aliases: [],
+                inline: true,
+                description: "Show just the art for a card",
+                help: '',
+                examples: ["!art lovisa coldeyes"]
             }
         };
         this.cardApi = "https://api.scryfall.com/cards/search?q=";
@@ -223,6 +230,9 @@ class MtgCardLoader {
             }
 
             let description = this.generateDescriptionText(card);
+            if (command.match(/^art/)) {
+                description = '🖌️' + card.artist
+            }
 
             // are we allowed to use custom emojis? cool, then do so, but make sure the title still fits
             if(hasEmojiPermission) {
@@ -238,6 +248,18 @@ class MtgCardLoader {
                 if (cards.length > 6) footer += '; ...';
             }
 
+            // image
+            let image = null
+            let thumbnail = null
+            if (card.image_uris) {
+                if (command.match(/^art/)) {
+                    image = {url: card.image_uris.art_crop}
+                } else {
+                    image = card.zoom ? {url: card.image_uris.normal} : null
+                    thumbnail = {url: card.image_uris.small}
+                }
+            }
+
             // instantiate embed object
             const embed = new Discord.MessageEmbed({
                 title,
@@ -245,8 +267,8 @@ class MtgCardLoader {
                 footer: {text: footer},
                 url: card.scryfall_uri,
                 color: this.getBorderColor(card.layout === 'transform' ? card.card_faces[0]:card),
-                thumbnail: card.image_uris ? {url: card.image_uris.small} : null,
-                image: card.zoom && card.image_uris ? {url: card.image_uris.normal} : null
+                thumbnail: thumbnail,
+                image: image
             });
 
             // add pricing, if requested

--- a/modules/card.js
+++ b/modules/card.js
@@ -271,6 +271,13 @@ class MtgCardLoader {
                 image: image
             });
 
+            // show crop art only
+            if (command.match(/^art/) && card.image_uris) {
+                embed.setImage(card.image_uris.art_crop);
+                embed.setDescription('🖌️ ' + card.artist);
+                embed.setThumbnail(null);
+            }
+            
             // add pricing, if requested
             if (command.match(/^price/) && card.prices) {
                 let prices = [];


### PR DESCRIPTION
This PR adds a new command to the card module that will post the "art crop" image from Scryfall, instead of the card image. It also replaces the card information with author information.
![image](https://user-images.githubusercontent.com/26642566/79744982-ace92300-834a-11ea-8add-0bd61697a2ef.png)
Unfortunately, Scryfall only offers the one resolution for art crop, so I removed the 🔍 react from the art-only messages, which required a small refactor
