### PR TITLE
Point CR source file to Venser's Journal

### DIFF
--- a/modules/rules/cr.js
+++ b/modules/rules/cr.js
@@ -5,8 +5,7 @@ const utils = require("../../utils");
 const log = utils.getLogger('cr');
 const Discord = require('discord.js');
 
-// Using the current CR as the default, not sure if they actually stick around once new ones are published
-const CR_ADDRESS = process.env.CR_ADDRESS || "https://media.wizards.com/2020/downloads/MagicCompRules%2020200417.txt";
+const CR_ADDRESS = process.env.CR_ADDRESS || "cr.vensersjournal.com";
 
 class CR {
     constructor() {

--- a/modules/rules/cr.js
+++ b/modules/rules/cr.js
@@ -5,7 +5,7 @@ const utils = require("../../utils");
 const log = utils.getLogger('cr');
 const Discord = require('discord.js');
 
-const CR_ADDRESS = process.env.CR_ADDRESS || "cr.vensersjournal.com";
+const CR_ADDRESS = process.env.CR_ADDRESS || "http://cr.vensersjournal.com";
 
 class CR {
     constructor() {


### PR DESCRIPTION
I have redirects set up on Venser's Journal that point at the most recent CR file, which I usually have downloaded and diffed within ~5 minutes of release. Ensures judgebot is getting up to date rules citations. Currently ~5mo out of date.