### PR TITLE
Use Scryfall rulings API instead of gatherer scraping.

### DIFF
--- a/modules/card.js
+++ b/modules/card.js
@@ -169,7 +169,8 @@ class MtgCardLoader {
                     resolve(rulings.join('\n'));
                 }
                 resolve("");
-            }
+            });
+        });
         return requestPromise;
     }
 


### PR DESCRIPTION
Scryfall has an endpoint for rulings.

In my experience, this is more reliable than the scraping because in some cases, the card that is a "hit" from the search might be an MTGO-only version that has no multiverse_id and therefore the rulings_uri is undefined.

An example is "Firesong and Sunspeaker".

This is the api result for the card (it selected the MTGO version): https://api.scryfall.com/cards/649256e0-22ed-4a04-b770-47c18bd9de05?format=json&pretty=true

But as you can see, there is an URL with the rulings in json format: https://api.scryfall.com/cards/649256e0-22ed-4a04-b770-47c18bd9de05/rulings

I've done these changes directly on GitHub, nothing was tested, so pardon if something is broken.