### PR TITLE
Improved CR Searching

### DIFF
--- a/modules/rules/cr.js
+++ b/modules/rules/cr.js
@@ -90,7 +90,6 @@ class CR {
                 }
             }
             entry = this.highlightRules(newEntry.join(" "));
-						console.log( entry )
 
             crEntries[number] = '';
             entry.split('\n').forEach(line => {
@@ -127,7 +126,6 @@ class CR {
 
     handleMessage(command, parameter, msg) {
         // use only the first parameter
-				console.log(parameter)
         let params = parameter.trim().toLowerCase().split(" ").map(p => p.replace(/\.$/, ""));
 				// Does the rule end in "." ? If so, only add that rule's text, not 123.4X
 				let addSubrules = parameter.trim().toLowerCase().split(" ").every(function(u, i){return u !== params[i];});

--- a/modules/rules/cr.js
+++ b/modules/rules/cr.js
@@ -18,9 +18,9 @@ class CR {
                 examples: ["!cr 508.1d", "!rule 702.15", "!define lifelink"]
             }
         };
-        this.location = "http://blogs.magicjudges.org/rules/cr";
+        this.location = "http://vensersjournal.com/";
         this.glossary = {};
-        this.thumbnail = 'https://assets.magicjudges.org/judge-banner/images/magic-judge.png';
+        this.thumbnail = 'https://c1.scryfall.com/file/scryfall-cards/art_crop/front/7/c/7cf33db9-6e34-4772-a533-ef09b4066e54.jpg?1562407276';
         this.crData = {};
         this.maxLength = 2040;
 
@@ -144,7 +144,7 @@ class CR {
             if (params[1] === "ex") params[0] += ' ex';
             embed.setTitle('CR - Rule ' + params[0].replace(/ ex$/,' Examples'))
                 .setDescription(this.appendSubrules(params[0],addSubrules))
-                .setURL(this.location + params[0].substr(0,3) + '/');
+                .setURL(this.location + params[0] + '/');
             if (this.crData[params[0] + ' ex']) {
                 embed.setFooter('Use "!'+Object.keys(this.commands)[0]+' '+params[0]+' ex" to see examples.');
             }

--- a/modules/rules/cr.js
+++ b/modules/rules/cr.js
@@ -72,7 +72,7 @@ class CR {
     }
 
     parseRules(crText, glossaryEntries) {
-        const ruleNumberPrefixRe = /^(\d{3}\.\w*)(\.)?/;
+        const ruleNumberPrefixRe = /^(\d{3}\.\w*)\.?/;
         const crEntries = {};
 
         for (let entry of crText.split("\n\n")) {
@@ -80,7 +80,7 @@ class CR {
                 continue;
             }
             const number = entry.split(" ", 1)[0].replace(/\.$/, "");
-            entry = entry.replace(ruleNumberPrefixRe, "__**$1$2**__");
+            entry = entry.replace(ruleNumberPrefixRe, "__**$1**__");
             const newEntry = [];
             for (const word of entry.split(" ")) {
                 if (glossaryEntries[word]) {


### PR DESCRIPTION
There are certain rules that can't be easily seen currently. For example, "CR 120.4" can not currently be searched without 120.4a,b,c,d also showing up. This fork adds a small change to this. "!cr 120.4" will return 120.4 and its subrules, but "!cr 120.4." will return only 120.4, no subrules. This mirrors how rules appear in the CR.