### PR TITLE
Remove reprints from Hangman

### DIFF
--- a/modules/hangman.js
+++ b/modules/hangman.js
@@ -196,7 +196,7 @@ class MtgHangman {
                 examples: ['!hangman', '!hangman easy', '!hangman guess yare']
             }
         };
-        this.cardApi = 'https://api.scryfall.com/cards/random';
+        this.cardApi = 'https://api.scryfall.com/cards/random?q=not%3Areprint+include%3Aextras';
         this.runningGames = {};
     }
 


### PR DESCRIPTION
When playing Hangman, certain cards, in particular basic lands, are chosen far more often than others due to the frequency of reprints those cards receive, which leads to repetition in the game.

Adding "?q=not%3Areprint+include%3Aextras" to the Scryfall API request for a random card removes reprints from the pool of possible cards, giving each card from the history of the game an equal chance of showing up. Including extras allows certain cards like playtest cards or schemes to still appear.