### PR TITLE
Replace Venser's Journal as a dependency

### DIFF
--- a/modules/rules/cr.js
+++ b/modules/rules/cr.js
@@ -5,7 +5,7 @@ const utils = require("../../utils");
 const log = utils.getLogger('cr');
 const Discord = require('discord.js');
 
-const CR_ADDRESS = process.env.CR_ADDRESS || "http://cr.vensersjournal.com";
+const CR_ADDRESS = process.env.CR_ADDRESS || "https://api.academyruins.com/link/cr"
 
 class CR {
     constructor() {


### PR DESCRIPTION
Resolves #167 (hopefully).

Venser's Journal is going fully offline on June 1st, and parts of the API are already offline (including the CR redirect link). A new API has been created as a replacement over at https://api.academyruins.com (code at https://github.com/lunakv/academyruins-api). This PR updates the dependency to make the rules endpoints work again.