### PR TITLE
Redirect CR links to Yawgatog 

### DIFF
--- a/modules/cr.ts
+++ b/modules/cr.ts
@@ -30,7 +30,7 @@ export default class CR {
   crData: Record<string, string>;
   static location = "http://yawgatog.com/resources/magic-rules/";
   static thumbnail =
-    "https://assets.magicjudges.org/judge-banner/images/magic-judge.png";
+    "https://yawgatog.com/icon-180x180.png";
   static maxLength = 2040;
   constructor() {
     this.glossary = {};

--- a/modules/cr.ts
+++ b/modules/cr.ts
@@ -28,7 +28,7 @@ export default class CR {
   suggestions: flexsearch.Index;
   glossary: Record<string, string>;
   crData: Record<string, string>;
-  static location = "http://blogs.magicjudges.org/rules/cr";
+  static location = "http://yawgatog.com/resources/magic-rules/";
   static thumbnail =
     "https://assets.magicjudges.org/judge-banner/images/magic-judge.png";
   static maxLength = 2040;
@@ -242,7 +242,7 @@ export default class CR {
       embed
         .setTitle("CR - Rule " + rule.replace(/ ex$/, " Examples"))
         .setDescription(this.appendSubrules(rule))
-        .setURL(CR.location + rule.substr(0, 3) + "/");
+        .setURL(CR.location + '#R' + rule.replace('.', ''));
       if (this.crData[rule + " ex"]) {
         embed.setFooter({
           text: `Use /${interaction.commandName} examples: True to see examples.`,
@@ -253,7 +253,7 @@ export default class CR {
       embed
         .setTitle(`CR - Glossary for "${rule}"`)
         .setDescription(this.glossary[rule])
-        .setURL(CR.location + "/cr-glossary/");
+        .setURL(CR.location + "#" + rule.toLowerCase());
       const gloss = this.glossary[rule].match(/rule (\d+\.\w+)/i);
       if (gloss && this.crData[rule[1]]) {
         embed.addFields({


### PR DESCRIPTION
Replaces #148.

### Issue
While the annotated MTR and IPG are still maintained on the MagicJudges.org site today, the hyperlinked CR has apparently not been touched for over two years now. This leads to problems when the bot cites a correct, up-to-date rule, but its link leads to an outdated or nonexistent link on the site.

### Fix
This PR replaces MagicJudges.org with [Yawgatog](https://yawgatog.com) as the provider for links regarding the CR. Yawgatog is a great ongoing project that creates a very usefully hyperlinked website from the CR, and it tends to update with new CR releases in a matter of days.

I also replaced the thumbnail icon with Yawgatog's, to make it patently clear the link doesn't lead to the MagicJudges blogs. If you'd rather keep the same thumbnail everywhere to be consistent, I can cherry-pick that change out of the PR.

### Screenshots
![2022-09-15_16-24](https://user-images.githubusercontent.com/38463785/190430041-84768c14-d59a-437c-869d-03c09469e7b9.png)
![2022-09-15_16-25](https://user-images.githubusercontent.com/38463785/190430033-9a8bb56b-38b1-4bf3-a454-02570b9a7b4b.png)

