### PR TITLE
Various /cr bug fixes

### DIFF
--- a/modules/cr.ts
+++ b/modules/cr.ts
@@ -122,8 +122,10 @@ export default class CR {
         continue;
       }
       const definition = `**${term}**\n${this.highlightRules(def.join("\n"))}`;
+      term = term.toLowerCase();
+      const entry = new GlossaryEntry(term, definition);
       for (const t of term.split(",")) {
-        glossaryEntries[t.trim().toLowerCase()] = new GlossaryEntry(term, definition);
+        glossaryEntries[t.trim()] = entry;
       }
     }
     return glossaryEntries;
@@ -189,7 +191,7 @@ export default class CR {
 
   // transform a rule / glossary name to a Yawgatog compatible HTML id
   ruleToUrlSegment(rule: string): string {
-    return rule.toLowerCase()
+    return rule
       .replace(/ ex$/, "") // examples don't have an id, just link to the corresponding rule
       .replace(/["',.]/g, "") // quotes, commas and dots are removed
       .replace(/[^a-z0-9-]/g, "_") // anything besides alphanum chars and hyphens becomes underscores

--- a/modules/cr.ts
+++ b/modules/cr.ts
@@ -184,15 +184,19 @@ export default class CR {
     return _.truncate(description, { length, separator: "\n" });
   }
 
-  // transform a rule / glossary name to a Yawgatog compatible HTML id
-  ruleToUrlSegment(rule: string): string {
-    return rule
+  // transform a rule / glossary name to a Yawgatog link
+  ruleToUrl(rule: string, isGlossary: boolean): string {
+    let url = CR.location + '#';
+    if (!isGlossary) url += 'R';
+    url += rule.toLowerCase()
       .replace(/ ex$/, "") // examples don't have an id, just link to the corresponding rule
       .replace(/["',.]/g, "") // quotes, commas and dots are removed
       .replace(/[^a-z0-9-]/g, "_") // anything besides alphanum chars and hyphens becomes underscores
       .replaceAll("_obsolete_", "") // "obsolete" is not part of the id
       .replace(/__+/g, "_") // reduce multiple consequent underscores to one
       .replace(/^_|_$/g, "") // remove leading/trailing underscores
+
+    return url;
   }
 
   @Slash({
@@ -262,7 +266,7 @@ export default class CR {
       embed
         .setTitle("CR - Rule " + rule.replace(/ ex$/, " Examples"))
         .setDescription(this.appendSubrules(rule))
-        .setURL(CR.location + '#R' + this.ruleToUrlSegment(rule));
+        .setURL(this.ruleToUrl(rule, false));
       if (this.crData[rule + " ex"]) {
         embed.setFooter({
           text: `Use /${interaction.commandName} examples: True to see examples.`,
@@ -274,7 +278,7 @@ export default class CR {
       embed
         .setTitle(`CR - Glossary for "${rule}"`)
         .setDescription(entry.definition)
-        .setURL(CR.location + "#" + this.ruleToUrlSegment(entry.term));
+        .setURL(this.ruleToUrl(entry.term, true));
       const gloss = entry.definition.match(/rule (\d+\.\w+)/i);
       if (gloss && this.crData[rule[1]]) {
         embed.addFields({

--- a/modules/cr.ts
+++ b/modules/cr.ts
@@ -189,7 +189,7 @@ export default class CR {
 
   // transform a rule / glossary name to a Yawgatog compatible HTML id
   ruleToUrlSegment(rule: string): string {
-	  return rule.toLowerCase()
+    return rule.toLowerCase()
       .replace(/ ex$/, "") // examples don't have an id, just link to the corresponding rule
       .replace(/["',.]/g, "") // quotes, commas and dots are removed
       .replace(/[^a-z0-9-]/g, "_") // anything besides alphanum chars and hyphens becomes underscores
@@ -255,7 +255,7 @@ export default class CR {
       return;
     }
 
-	  rule = rule.toLowerCase(); // all dictionaries are keyed by lower case strings
+    rule = rule.toLowerCase(); // all dictionaries are keyed by lower case strings
 
     // check first for CR paragraph match
     if (this.crData[rule]) {

--- a/modules/cr.ts
+++ b/modules/cr.ts
@@ -28,7 +28,7 @@ export default class CR {
   suggestions: flexsearch.Index;
   glossary: Record<string, string>;
   crData: Record<string, string>;
-  static location = "http://yawgatog.com/resources/magic-rules/";
+  static location = "https://yawgatog.com/resources/magic-rules/";
   static thumbnail =
     "https://yawgatog.com/icon-180x180.png";
   static maxLength = 2040;
@@ -177,6 +177,10 @@ export default class CR {
     return _.truncate(description, { length, separator: "\n" });
   }
 
+  ruleToUrlSegment(rule: string): string {
+	return rule.replace(/ ex$/, "").replace(/["',.]/g, "").replace(/[^a-z0-9-]/g, "_").replaceAll("_obsolete_", "").replace(/__+/g, "_").replace(/^_|_$/g, "")
+  }
+
   @Slash({
     name: "cr",
     description: "Show a rule or definition from the Comprehensive Rulebook",
@@ -234,6 +238,8 @@ export default class CR {
       return;
     }
 
+	  rule = rule.toLowerCase();
+
     // check first for CR paragraph match
     if (this.crData[rule]) {
       if (ex) {
@@ -242,7 +248,7 @@ export default class CR {
       embed
         .setTitle("CR - Rule " + rule.replace(/ ex$/, " Examples"))
         .setDescription(this.appendSubrules(rule))
-        .setURL(CR.location + '#R' + rule.replace('.', ''));
+        .setURL(CR.location + '#R' + this.ruleToUrlSegment(rule));
       if (this.crData[rule + " ex"]) {
         embed.setFooter({
           text: `Use /${interaction.commandName} examples: True to see examples.`,
@@ -253,7 +259,7 @@ export default class CR {
       embed
         .setTitle(`CR - Glossary for "${rule}"`)
         .setDescription(this.glossary[rule])
-        .setURL(CR.location + "#" + rule.toLowerCase());
+        .setURL(CR.location + "#" + this.ruleToUrlSegment(rule));
       const gloss = this.glossary[rule].match(/rule (\d+\.\w+)/i);
       if (gloss && this.crData[rule[1]]) {
         embed.addFields({

--- a/modules/cr.ts
+++ b/modules/cr.ts
@@ -23,14 +23,9 @@ const CR_ADDRESS =
   process.env.CR_ADDRESS || "https://api.academyruins.com/link/cr";
 
 // the glossary dict also stores shorthand keys for fuzzy searching, so we need to store the full entry to properly link to it
-class GlossaryEntry {
+interface GlossaryEntry {
   term: string;
   definition: string;
-
-  constructor(term: string, definition: string) {
-    this.term = term;
-    this.definition = definition;
-  }
 }
 
 @Discord()
@@ -123,9 +118,9 @@ export default class CR {
       }
       const definition = `**${term}**\n${this.highlightRules(def.join("\n"))}`;
       term = term.toLowerCase();
-      const entry = new GlossaryEntry(term, definition);
+      const glossaryEntry: GlossaryEntry = {term, definition};
       for (const t of term.split(",")) {
-        glossaryEntries[t.trim()] = entry;
+        glossaryEntries[t.trim()] = glossaryEntry;
       }
     }
     return glossaryEntries;

--- a/test/rules/cr.ts
+++ b/test/rules/cr.ts
@@ -1,0 +1,66 @@
+import CR from "../../modules/cr.js";
+import {expect} from "chai";
+
+describe('CR', function () {
+  let cr: any;
+  beforeEach(function () {
+    cr = new CR();
+  })
+
+  describe('output', function () {
+    describe('#ruleToUrl', function () {
+      const ruleBaseUrl = 'https://yawgatog.com/resources/magic-rules/#R';
+      it('should work for rule sections', function () {
+        const url = cr.ruleToUrl('4', false);
+        expect(url).to.equal(ruleBaseUrl + '4');
+      });
+      it('should work for non-dotted rules', function () {
+        const url = cr.ruleToUrl('702', false);
+        expect(url).to.equal(ruleBaseUrl + '702');
+      })
+      it('should work for regular rules', function () {
+        let url = cr.ruleToUrl('100.1', false);
+        expect(url).to.equal(ruleBaseUrl + '1001');
+      });
+      it('should work for subrules', function () {
+        const url = cr.ruleToUrl('104.3a', false);
+        expect(url).to.equal(ruleBaseUrl + '1043a');
+      });
+      // examples don't have their own IDs on the page
+      it('should link to correct rule for examples', function () {
+        const url = cr.ruleToUrl('614.12 ex', false);
+        expect(url).to.equal(ruleBaseUrl + '61412');
+      });
+      it('should link to correct subrule for examples', function () {
+        const url = cr.ruleToUrl('607.5a ex', false);
+        expect(url).to.equal(ruleBaseUrl + '6075a');
+      });
+
+      const glossBaseUrl = 'https://yawgatog.com/resources/magic-rules/#'
+      it('should work for simple glossary entries', function () {
+        const url = cr.ruleToUrl('abandon', true);
+        expect(url).to.equal(glossBaseUrl + 'abandon');
+      });
+      it('should work for multiple word glossary entries', function () {
+        const url = cr.ruleToUrl('Alternating Teams Variant', true);
+        expect(url).to.equal(glossBaseUrl + 'alternating_teams_variant');
+      });
+      it('should work for glossary entries with punctuation', function () {
+        let url = cr.ruleToUrl('Active Player, Nonactive Player Order', true);
+        expect(url).to.equal(glossBaseUrl + 'active_player_nonactive_player_order');
+        url = cr.ruleToUrl('Free-for-All', true);
+        expect(url).to.equal(glossBaseUrl + 'free-for-all');
+        url = cr.ruleToUrl('Double-Faced Cards', true);
+        expect(url).to.equal(glossBaseUrl + 'double-faced_cards');
+        url = cr.ruleToUrl("City's Blessing", true);
+        expect(url).to.equal(glossBaseUrl + 'citys_blessing');
+        url = cr.ruleToUrl('partner, "partner with [name]"', true);
+        expect(url).to.equal(glossBaseUrl + 'partner_partner_with_name');
+      });
+      it('should work for obsolete glossary entries', function () {
+        const url = cr.ruleToUrl('mana burn (obsolete)', true);
+        expect(url).to.equal(glossBaseUrl + 'mana_burn');
+      })
+    })
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,7 @@
   ],
     "ts-node": {
     "compilerOptions": {
-      "module": "CommonJS"
+      "module": "ES2022"
     }
   }
 }


### PR DESCRIPTION
This PR addresses several issues in the `/cr` slash command code.

- The rules reference to Yawgatog was linked with plain HTTP, even though the site uses HTTPS. This has been rectified.
- The `SlashChoice` import was unused and thus removed.
- The logic for converting rules into element IDs was incomplete. After consulting with Yawgatog's maintainer, a new method was added that produces fully correct transformations for these links.
- The command was case-sensitive. For example, `/cr Unearth` would return no results, even though `/cr unearth` would lead to the correct glossary entry (titled "Unearth"). The search term is now explicitly lowercased to make the search case-insensitive.
- Due to the fuzzy nature of glossary searching, sometimes the actual title of an entry would be different than the search that matched it. Because of this, the contents of `rule` itself aren't necessarily sufficient to produce a valid link to that glossary entry. *(For example, `/cr partner` would create a link to `#partner`, but the correct link would be to the full `#partner_partner_with_name`)*. This has been addressed by the glossary dict now storing not only the definitions themselves, but also the actual value of the term the search is referring to.