### PR TITLE
Change CR character encoding

### DIFF
--- a/modules/cr.ts
+++ b/modules/cr.ts
@@ -56,7 +56,7 @@ export default class CR {
     try {
       const res = await fetch(CR_ADDRESS);
       const buff = await res.buffer();
-      this.parseCr(iconv.decode(buff, "utf-8"));
+      this.parseCr(iconv.decode(buff, "utf-16"));
       this.buildSuggestions();
     } catch (err) {
       log.error("Error loading CR: " + err);


### PR DESCRIPTION
Related to #181.

Updates the `iconv` command to decode the CR text using UTF-16, which is how the latest version (BRO) is encoded. 

As an alternative to this PR, you can set the bot to run with `CR_ADDRESS=https://api.academyruins.com/file/cr/BRO`, which will fetch a utf-8 version of the CR. Both methods were tested locally to be working, but both are temporary by nature. See #181 on discussions of a more permanent solution. 