### PR TITLE
Use stable upstream for CR file

### DIFF
--- a/modules/cr.ts
+++ b/modules/cr.ts
@@ -20,7 +20,7 @@ import flexsearch from "flexsearch";
 
 const log = utils.getLogger("cr");
 const CR_ADDRESS =
-  process.env.CR_ADDRESS || "https://api.academyruins.com/link/cr";
+  process.env.CR_ADDRESS || "https://api.academyruins.com/file/cr";
 
 // the glossary dict also stores shorthand keys for fuzzy searching, so we need to store the full entry to properly link to it
 interface GlossaryEntry {
@@ -56,7 +56,7 @@ export default class CR {
     try {
       const res = await fetch(CR_ADDRESS);
       const buff = await res.arrayBuffer();
-      this.parseCr(iconv.decode(Buffer.from(buff), "utf-16"));
+      this.parseCr(iconv.decode(Buffer.from(buff), "utf-8"));
       this.buildSuggestions();
     } catch (err) {
       log.error("Error loading CR: " + err);
@@ -88,9 +88,6 @@ export default class CR {
   }
 
   parseCr(crText: string) {
-    // Standardise all linebreaks. \r\n → \n for pre-2020 rules, but for 2020 we have to \r → \n
-    crText = crText.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
-
     let rulesText = crText.substring(crText.search("\nCredits\n") + 9).trim();
     const glossaryStartIndex = rulesText.search("\nGlossary\n") + 10;
     const glossaryText = rulesText


### PR DESCRIPTION
WotC changed their CR character encoding... again. (all the way back to utf-8, ironically)

As I've seemingly become the point person on some judge servers for issues related to judgebot, I caved and just wrote an API route that returns a "stable" version of the CR file. The response will be the exact same as the link served directly by WotC, except [it is guaranteed](https://api.academyruins.com/docs#section/Response-Encoding-and-Formatting) to be in UTF-8 with LF line endings. (It may also be delayed ever so slightly behind the `/link` route, but it shouldn't ever really be enough to become a problem). 

I am so f*%&ing done dealing with this...

PS: If this is merged, the actual content will be served from my VPS instead of WotC's servers. How often does the bot refresh the CR data? I don't expect it to be an issue, but just for my own edification I'd still like to know—it doesn't seem to be governed by anything in the repo as far as I can tell.